### PR TITLE
feat(frontend): graphql のスキーマ変更対応

### DIFF
--- a/apps/frontend/codegen.ts
+++ b/apps/frontend/codegen.ts
@@ -4,6 +4,17 @@ const config: CodegenConfig = {
   overwrite: true,
   schema: "https://tatsutakeinjp.hasura.app/v1/graphql",
   documents: ["src/**/*.tsx", "src/**/*.ts"],
+  config: {
+    namingConvention: {
+      typeNames: "change-case-all#pascalCase",
+      enumValues: "change-case-all#upperCase",
+      transformUnderscore: true,
+    },
+    scalars: {
+      uuid: "string",
+      timestamptz: "Date",
+    },
+  },
   generates: {
     "src/gql/": {
       preset: "client",

--- a/apps/frontend/graphql.schema.json
+++ b/apps/frontend/graphql.schema.json
@@ -9,6 +9,799 @@
     },
     "types": [
       {
+        "kind": "OBJECT",
+        "name": "Assets",
+        "description": "アセット",
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": "説明文",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "height",
+            "description": "高さ",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "smallint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "アセットID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mimeType",
+            "description": "MimeType",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posts",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinctOn",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PostsSelectColumn",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PostsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostsBoolExp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Posts",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": "ファイルサイズ",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "アセットソース",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": "幅",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "smallint",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetsBoolExp",
+        "description": "Boolean expression to filter rows from the table \"assets\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AssetsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AssetsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "height",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SmallintComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mimeType",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IntComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SmallintComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetsOrderBy",
+        "description": "Ordering options when selecting data from \"assets\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "height",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mimeType",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postsAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsAggregateOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AssetsSelectColumn",
+        "description": "select columns of table \"assets\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "createdAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "height",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mimeType",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetsStreamCursorInput",
+        "description": "Streaming cursor of the table \"assets\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initialValue",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AssetsStreamCursorValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "CursorOrdering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetsStreamCursorValueInput",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": "説明文",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "height",
+            "description": "高さ",
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "アセットID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mimeType",
+            "description": "MimeType",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": "ファイルサイズ",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "アセットソース",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": "幅",
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
@@ -16,6 +809,29 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CursorOrdering",
+        "description": "ordering argument of a cursor",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": "ascending ordering of the cursor",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": "descending ordering of the cursor",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -30,7 +846,7 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "Int_comparison_exp",
+        "name": "IntComparisonExp",
         "description": "Boolean expression to compare columns of type \"Int\". All fields are combined with logical 'AND'.",
         "fields": null,
         "inputFields": [
@@ -91,7 +907,7 @@
             "deprecationReason": null
           },
           {
-            "name": "_is_null",
+            "name": "_isNull",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -164,6 +980,2614 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "OrderBy",
+        "description": "column ordering options",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": "in ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ASC_NULLS_FIRST",
+            "description": "in ascending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ASC_NULLS_LAST",
+            "description": "in ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": "in descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC_NULLS_FIRST",
+            "description": "in descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC_NULLS_LAST",
+            "description": "in descending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PostTags",
+        "description": "ポストとタグの関連付け",
+        "fields": [
+          {
+            "name": "post",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Posts",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postId",
+            "description": "ポストID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Tags",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": "タグID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsAggregateOrderBy",
+        "description": "order by aggregate values of table \"post_tags\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsMaxOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsMinOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsBoolExp",
+        "description": "Boolean expression to filter rows from the table \"post_tags\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostTagsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostTagsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TagsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsMaxOrderBy",
+        "description": "order by max() on columns of table \"post_tags\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "postId",
+            "description": "ポストID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": "タグID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsMinOrderBy",
+        "description": "order by min() on columns of table \"post_tags\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "postId",
+            "description": "ポストID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": "タグID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsOrderBy",
+        "description": "Ordering options when selecting data from \"post_tags\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "post",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TagsOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "PostTagsSelectColumn",
+        "description": "select columns of table \"post_tags\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "postId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsStreamCursorInput",
+        "description": "Streaming cursor of the table \"post_tags\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initialValue",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "PostTagsStreamCursorValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "CursorOrdering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostTagsStreamCursorValueInput",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "postId",
+            "description": "ポストID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tagId",
+            "description": "タグID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Posts",
+        "description": "ポスト",
+        "fields": [
+          {
+            "name": "content",
+            "description": "内容",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImage",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Assets",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": "カバー画像",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": "抜粋",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "ポスト ID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tags",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinctOn",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PostTagsSelectColumn",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PostTagsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostTagsBoolExp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PostTags",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "公開日時",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seo",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Seos",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": "SEO",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "ラベル文字列",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsAggregateOrderBy",
+        "description": "order by aggregate values of table \"posts\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsMaxOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsMinOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsBoolExp",
+        "description": "Boolean expression to filter rows from the table \"posts\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "content",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tags",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seo",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SeosBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsMaxOrderBy",
+        "description": "order by max() on columns of table \"posts\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "content",
+            "description": "内容",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": "カバー画像",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": "抜粋",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "ポスト ID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "公開日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": "SEO",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "ラベル文字列",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsMinOrderBy",
+        "description": "order by min() on columns of table \"posts\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "content",
+            "description": "内容",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": "カバー画像",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": "抜粋",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "ポスト ID",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "公開日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": "SEO",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "ラベル文字列",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsOrderBy",
+        "description": "Ordering options when selecting data from \"posts\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "content",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetsOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tagsAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsAggregateOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seo",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SeosOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "PostsSelectColumn",
+        "description": "select columns of table \"posts\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "content",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsStreamCursorInput",
+        "description": "Streaming cursor of the table \"posts\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initialValue",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "PostsStreamCursorValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "CursorOrdering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PostsStreamCursorValueInput",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "content",
+            "description": "内容",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImageId",
+            "description": "カバー画像",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "excerpt",
+            "description": "抜粋",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "ポスト ID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "公開日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoId",
+            "description": "SEO",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "ラベル文字列",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Seos",
+        "description": "SEO",
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "説明文",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "SEO ID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ogImageUrl",
+            "description": "カスタム OG 画像 URL ( 1280✕720 )",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posts",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinctOn",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PostsSelectColumn",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PostsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostsBoolExp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Posts",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SeosBoolExp",
+        "description": "Boolean expression to filter rows from the table \"seos\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SeosBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SeosBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SeosBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ogImageUrl",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SeosOrderBy",
+        "description": "Ordering options when selecting data from \"seos\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ogImageUrl",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postsAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostsAggregateOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SeosSelectColumn",
+        "description": "select columns of table \"seos\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "createdAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ogImageUrl",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SeosStreamCursorInput",
+        "description": "Streaming cursor of the table \"seos\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initialValue",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "SeosStreamCursorValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "CursorOrdering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SeosStreamCursorValueInput",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletedAt",
+            "description": "削除日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "説明文",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "SEO ID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ogImageUrl",
+            "description": "カスタム OG 画像 URL ( 1280✕720 )",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "タイトル",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SmallintComparisonExp",
+        "description": "Boolean expression to compare columns of type \"smallint\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "smallint",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_isNull",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "smallint",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "smallint",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
@@ -175,7 +3599,7 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "String_comparison_exp",
+        "name": "StringComparisonExp",
         "description": "Boolean expression to compare columns of type \"String\". All fields are combined with logical 'AND'.",
         "fields": null,
         "inputFields": [
@@ -260,7 +3684,7 @@
             "deprecationReason": null
           },
           {
-            "name": "_is_null",
+            "name": "_isNull",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -418,6 +3842,837 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Tags",
+        "description": "タグ",
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "説明文",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "タグID",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tags",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinctOn",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PostTagsSelectColumn",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PostTagsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PostTagsBoolExp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PostTags",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": "タグ",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TagsBoolExp",
+        "description": "Boolean expression to filter rows from the table \"tags\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TagsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TagsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TagsBoolExp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UuidComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tags",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsBoolExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TimestamptzComparisonExp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TagsOrderBy",
+        "description": "Ordering options when selecting data from \"tags\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "post_tagsAggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PostTagsAggregateOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "OrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "TagsSelectColumn",
+        "description": "select columns of table \"tags\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "createdAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TagsStreamCursorInput",
+        "description": "Streaming cursor of the table \"tags\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initialValue",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "TagsStreamCursorValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "CursorOrdering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TagsStreamCursorValueInput",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": "作成日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "説明文",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "タグID",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tag",
+            "description": "タグ",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "更新日時",
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TimestamptzComparisonExp",
+        "description": "Boolean expression to compare columns of type \"timestamptz\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "timestamptz",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_isNull",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "timestamptz",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UuidComparisonExp",
+        "description": "Boolean expression to compare columns of type \"uuid\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_isNull",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -1337,2626 +5592,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "assets",
-        "description": "アセット",
-        "fields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file_name",
-            "description": "説明文",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": "高さ",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "smallint",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "アセットID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mime_type",
-            "description": "MimeType",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts",
-            "description": "An array relationship",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "posts_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "posts_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "posts",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "size",
-            "description": "ファイルサイズ",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "アセットソース",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "width",
-            "description": "幅",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "smallint",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "assets_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"assets\". All fields are combined with a logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_and",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "assets_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_not",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "assets_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_or",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "assets_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file_name",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "smallint_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mime_type",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "size",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "width",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "smallint_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "assets_order_by",
-        "description": "Ordering options when selecting data from \"assets\".",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file_name",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mime_type",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts_aggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_aggregate_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "size",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "width",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "assets_select_column",
-        "description": "select columns of table \"assets\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "created_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file_name",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mime_type",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "size",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "width",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "assets_stream_cursor_input",
-        "description": "Streaming cursor of the table \"assets\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "initial_value",
-            "description": "Stream column input with initial value",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "assets_stream_cursor_value_input",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ordering",
-            "description": "cursor ordering",
-            "type": {
-              "kind": "ENUM",
-              "name": "cursor_ordering",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "assets_stream_cursor_value_input",
-        "description": "Initial value of the column from where the streaming should start",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file_name",
-            "description": "説明文",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "height",
-            "description": "高さ",
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "アセットID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mime_type",
-            "description": "MimeType",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "size",
-            "description": "ファイルサイズ",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "アセットソース",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "width",
-            "description": "幅",
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "cursor_ordering",
-        "description": "ordering argument of a cursor",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "ASC",
-            "description": "ascending ordering of the cursor",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "DESC",
-            "description": "descending ordering of the cursor",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "order_by",
-        "description": "column ordering options",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "asc",
-            "description": "in ascending order, nulls last",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "asc_nulls_first",
-            "description": "in ascending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "asc_nulls_last",
-            "description": "in ascending order, nulls last",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "desc",
-            "description": "in descending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "desc_nulls_first",
-            "description": "in descending order, nulls first",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "desc_nulls_last",
-            "description": "in descending order, nulls last",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "post_tags",
-        "description": "ポストとタグの関連付け",
-        "fields": [
-          {
-            "name": "post",
-            "description": "An object relationship",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "posts",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_id",
-            "description": "ポストID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": "An object relationship",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "tags",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": "タグID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_aggregate_order_by",
-        "description": "order by aggregate values of table \"post_tags\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "count",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "max",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_max_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "min",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_min_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"post_tags\". All fields are combined with a logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_and",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_not",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_or",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "tags_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_max_order_by",
-        "description": "order by max() on columns of table \"post_tags\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "post_id",
-            "description": "ポストID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": "タグID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_min_order_by",
-        "description": "order by min() on columns of table \"post_tags\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "post_id",
-            "description": "ポストID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": "タグID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_order_by",
-        "description": "Ordering options when selecting data from \"post_tags\".",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "post",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "tags_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "post_tags_select_column",
-        "description": "select columns of table \"post_tags\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "post_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_stream_cursor_input",
-        "description": "Streaming cursor of the table \"post_tags\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "initial_value",
-            "description": "Stream column input with initial value",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "post_tags_stream_cursor_value_input",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ordering",
-            "description": "cursor ordering",
-            "type": {
-              "kind": "ENUM",
-              "name": "cursor_ordering",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "post_tags_stream_cursor_value_input",
-        "description": "Initial value of the column from where the streaming should start",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "post_id",
-            "description": "ポストID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag_id",
-            "description": "タグID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "posts",
-        "description": "ポスト",
-        "fields": [
-          {
-            "name": "content",
-            "description": "内容",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "coverImage",
-            "description": "An object relationship",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "assets",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": "カバー画像",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": "抜粋",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "ポスト ID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags",
-            "description": "An array relationship",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "post_tags_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "post_tags_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "post_tags",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": "公開日時",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo",
-            "description": "An object relationship",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "seos",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": "SEO",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "ラベル文字列",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_aggregate_order_by",
-        "description": "order by aggregate values of table \"posts\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "count",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "max",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_max_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "min",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_min_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"posts\". All fields are combined with a logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_and",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_not",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_or",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "content",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "coverImage",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "assets_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "seos_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_max_order_by",
-        "description": "order by max() on columns of table \"posts\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "content",
-            "description": "内容",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": "カバー画像",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": "抜粋",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "ポスト ID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": "公開日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": "SEO",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "ラベル文字列",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_min_order_by",
-        "description": "order by min() on columns of table \"posts\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "content",
-            "description": "内容",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": "カバー画像",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": "抜粋",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "ポスト ID",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": "公開日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": "SEO",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "ラベル文字列",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_order_by",
-        "description": "Ordering options when selecting data from \"posts\".",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "content",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "coverImage",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "assets_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags_aggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_aggregate_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "seos_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "posts_select_column",
-        "description": "select columns of table \"posts\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "content",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_stream_cursor_input",
-        "description": "Streaming cursor of the table \"posts\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "initial_value",
-            "description": "Stream column input with initial value",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "posts_stream_cursor_value_input",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ordering",
-            "description": "cursor ordering",
-            "type": {
-              "kind": "ENUM",
-              "name": "cursor_ordering",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "posts_stream_cursor_value_input",
-        "description": "Initial value of the column from where the streaming should start",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "content",
-            "description": "内容",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cover_image_id",
-            "description": "カバー画像",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "excerpt",
-            "description": "抜粋",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "ポスト ID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published_at",
-            "description": "公開日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "seo_id",
-            "description": "SEO",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "ラベル文字列",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "query_root",
         "description": null,
         "fields": [
@@ -3965,7 +5600,7 @@
             "description": "fetch data from the table: \"assets\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -3975,7 +5610,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "assets_select_column",
+                      "name": "AssetsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -4009,7 +5644,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -4019,7 +5654,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "assets_order_by",
+                      "name": "AssetsOrderBy",
                       "ofType": null
                     }
                   }
@@ -4033,7 +5668,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "assets_bool_exp",
+                  "name": "AssetsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -4052,7 +5687,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "assets",
+                    "name": "Assets",
                     "ofType": null
                   }
                 }
@@ -4062,7 +5697,7 @@
             "deprecationReason": null
           },
           {
-            "name": "assets_by_pk",
+            "name": "assetsByPk",
             "description": "fetch data from the table: \"assets\" using primary key columns",
             "args": [
               {
@@ -4084,18 +5719,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "assets",
+              "name": "Assets",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "post_tags",
-            "description": "An array relationship",
+            "name": "postTags",
+            "description": "fetch data from the table: \"post_tags\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -4105,7 +5740,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "post_tags_select_column",
+                      "name": "PostTagsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -4139,7 +5774,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -4149,7 +5784,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "post_tags_order_by",
+                      "name": "PostTagsOrderBy",
                       "ofType": null
                     }
                   }
@@ -4163,7 +5798,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
+                  "name": "PostTagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -4182,7 +5817,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "post_tags",
+                    "name": "PostTags",
                     "ofType": null
                   }
                 }
@@ -4192,11 +5827,11 @@
             "deprecationReason": null
           },
           {
-            "name": "post_tags_by_pk",
+            "name": "postTagsByPk",
             "description": "fetch data from the table: \"post_tags\" using primary key columns",
             "args": [
               {
-                "name": "post_id",
+                "name": "postId",
                 "description": "ポストID",
                 "type": {
                   "kind": "NON_NULL",
@@ -4212,7 +5847,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "tag_id",
+                "name": "tagId",
                 "description": "タグID",
                 "type": {
                   "kind": "NON_NULL",
@@ -4230,7 +5865,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "post_tags",
+              "name": "PostTags",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4241,7 +5876,7 @@
             "description": "An array relationship",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -4251,7 +5886,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "posts_select_column",
+                      "name": "PostsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -4285,7 +5920,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -4295,7 +5930,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "posts_order_by",
+                      "name": "PostsOrderBy",
                       "ofType": null
                     }
                   }
@@ -4309,7 +5944,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
+                  "name": "PostsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -4328,7 +5963,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "posts",
+                    "name": "Posts",
                     "ofType": null
                   }
                 }
@@ -4338,7 +5973,7 @@
             "deprecationReason": null
           },
           {
-            "name": "posts_by_pk",
+            "name": "postsByPk",
             "description": "fetch data from the table: \"posts\" using primary key columns",
             "args": [
               {
@@ -4360,7 +5995,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "posts",
+              "name": "Posts",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4371,7 +6006,7 @@
             "description": "fetch data from the table: \"seos\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -4381,7 +6016,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "seos_select_column",
+                      "name": "SeosSelectColumn",
                       "ofType": null
                     }
                   }
@@ -4415,7 +6050,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -4425,7 +6060,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "seos_order_by",
+                      "name": "SeosOrderBy",
                       "ofType": null
                     }
                   }
@@ -4439,7 +6074,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "seos_bool_exp",
+                  "name": "SeosBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -4458,7 +6093,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "seos",
+                    "name": "Seos",
                     "ofType": null
                   }
                 }
@@ -4468,7 +6103,7 @@
             "deprecationReason": null
           },
           {
-            "name": "seos_by_pk",
+            "name": "seosByPk",
             "description": "fetch data from the table: \"seos\" using primary key columns",
             "args": [
               {
@@ -4490,7 +6125,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "seos",
+              "name": "Seos",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4501,7 +6136,7 @@
             "description": "fetch data from the table: \"tags\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -4511,7 +6146,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "tags_select_column",
+                      "name": "TagsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -4545,7 +6180,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -4555,7 +6190,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "tags_order_by",
+                      "name": "TagsOrderBy",
                       "ofType": null
                     }
                   }
@@ -4569,7 +6204,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "tags_bool_exp",
+                  "name": "TagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -4588,7 +6223,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "tags",
+                    "name": "Tags",
                     "ofType": null
                   }
                 }
@@ -4598,7 +6233,7 @@
             "deprecationReason": null
           },
           {
-            "name": "tags_by_pk",
+            "name": "tagsByPk",
             "description": "fetch data from the table: \"tags\" using primary key columns",
             "args": [
               {
@@ -4620,7 +6255,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "tags",
+              "name": "Tags",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4629,675 +6264,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "seos",
-        "description": "SEO",
-        "fields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "説明文",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "SEO ID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "og_image_url",
-            "description": "カスタム OG 画像 URL ( 1280✕720 )",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts",
-            "description": "An array relationship",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "posts_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "posts_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "posts",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "seos_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"seos\". All fields are combined with a logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_and",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "seos_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_not",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "seos_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_or",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "seos_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "og_image_url",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "seos_order_by",
-        "description": "Ordering options when selecting data from \"seos\".",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "og_image_url",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "posts_aggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "posts_aggregate_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "seos_select_column",
-        "description": "select columns of table \"seos\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "created_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "og_image_url",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "seos_stream_cursor_input",
-        "description": "Streaming cursor of the table \"seos\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "initial_value",
-            "description": "Stream column input with initial value",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "seos_stream_cursor_value_input",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ordering",
-            "description": "cursor ordering",
-            "type": {
-              "kind": "ENUM",
-              "name": "cursor_ordering",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "seos_stream_cursor_value_input",
-        "description": "Initial value of the column from where the streaming should start",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleted_at",
-            "description": "削除日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "説明文",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "SEO ID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "og_image_url",
-            "description": "カスタム OG 画像 URL ( 1280✕720 )",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": "タイトル",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -5312,141 +6278,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "smallint_comparison_exp",
-        "description": "Boolean expression to compare columns of type \"smallint\". All fields are combined with logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_eq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_in",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "smallint",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_is_null",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_neq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "smallint",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_nin",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "smallint",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "subscription_root",
         "description": null,
@@ -5456,7 +6287,7 @@
             "description": "fetch data from the table: \"assets\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -5466,7 +6297,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "assets_select_column",
+                      "name": "AssetsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -5500,7 +6331,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -5510,7 +6341,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "assets_order_by",
+                      "name": "AssetsOrderBy",
                       "ofType": null
                     }
                   }
@@ -5524,7 +6355,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "assets_bool_exp",
+                  "name": "AssetsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -5543,7 +6374,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "assets",
+                    "name": "Assets",
                     "ofType": null
                   }
                 }
@@ -5553,7 +6384,7 @@
             "deprecationReason": null
           },
           {
-            "name": "assets_by_pk",
+            "name": "assetsByPk",
             "description": "fetch data from the table: \"assets\" using primary key columns",
             "args": [
               {
@@ -5575,18 +6406,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "assets",
+              "name": "Assets",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "assets_stream",
+            "name": "assetsStream",
             "description": "fetch data from the table in a streaming manner: \"assets\"",
             "args": [
               {
-                "name": "batch_size",
+                "name": "batchSize",
                 "description": "maximum number of rows returned in a single batch",
                 "type": {
                   "kind": "NON_NULL",
@@ -5612,7 +6443,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "assets_stream_cursor_input",
+                      "name": "AssetsStreamCursorInput",
                       "ofType": null
                     }
                   }
@@ -5626,7 +6457,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "assets_bool_exp",
+                  "name": "AssetsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -5645,7 +6476,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "assets",
+                    "name": "Assets",
                     "ofType": null
                   }
                 }
@@ -5655,11 +6486,11 @@
             "deprecationReason": null
           },
           {
-            "name": "post_tags",
-            "description": "An array relationship",
+            "name": "postTags",
+            "description": "fetch data from the table: \"post_tags\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -5669,7 +6500,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "post_tags_select_column",
+                      "name": "PostTagsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -5703,7 +6534,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -5713,7 +6544,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "post_tags_order_by",
+                      "name": "PostTagsOrderBy",
                       "ofType": null
                     }
                   }
@@ -5727,7 +6558,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
+                  "name": "PostTagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -5746,7 +6577,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "post_tags",
+                    "name": "PostTags",
                     "ofType": null
                   }
                 }
@@ -5756,11 +6587,11 @@
             "deprecationReason": null
           },
           {
-            "name": "post_tags_by_pk",
+            "name": "postTagsByPk",
             "description": "fetch data from the table: \"post_tags\" using primary key columns",
             "args": [
               {
-                "name": "post_id",
+                "name": "postId",
                 "description": "ポストID",
                 "type": {
                   "kind": "NON_NULL",
@@ -5776,7 +6607,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "tag_id",
+                "name": "tagId",
                 "description": "タグID",
                 "type": {
                   "kind": "NON_NULL",
@@ -5794,18 +6625,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "post_tags",
+              "name": "PostTags",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "post_tags_stream",
+            "name": "postTagsStream",
             "description": "fetch data from the table in a streaming manner: \"post_tags\"",
             "args": [
               {
-                "name": "batch_size",
+                "name": "batchSize",
                 "description": "maximum number of rows returned in a single batch",
                 "type": {
                   "kind": "NON_NULL",
@@ -5831,7 +6662,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "post_tags_stream_cursor_input",
+                      "name": "PostTagsStreamCursorInput",
                       "ofType": null
                     }
                   }
@@ -5845,7 +6676,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
+                  "name": "PostTagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -5864,7 +6695,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "post_tags",
+                    "name": "PostTags",
                     "ofType": null
                   }
                 }
@@ -5878,7 +6709,7 @@
             "description": "An array relationship",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -5888,7 +6719,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "posts_select_column",
+                      "name": "PostsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -5922,7 +6753,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -5932,7 +6763,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "posts_order_by",
+                      "name": "PostsOrderBy",
                       "ofType": null
                     }
                   }
@@ -5946,7 +6777,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
+                  "name": "PostsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -5965,7 +6796,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "posts",
+                    "name": "Posts",
                     "ofType": null
                   }
                 }
@@ -5975,7 +6806,7 @@
             "deprecationReason": null
           },
           {
-            "name": "posts_by_pk",
+            "name": "postsByPk",
             "description": "fetch data from the table: \"posts\" using primary key columns",
             "args": [
               {
@@ -5997,18 +6828,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "posts",
+              "name": "Posts",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "posts_stream",
+            "name": "postsStream",
             "description": "fetch data from the table in a streaming manner: \"posts\"",
             "args": [
               {
-                "name": "batch_size",
+                "name": "batchSize",
                 "description": "maximum number of rows returned in a single batch",
                 "type": {
                   "kind": "NON_NULL",
@@ -6034,7 +6865,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "posts_stream_cursor_input",
+                      "name": "PostsStreamCursorInput",
                       "ofType": null
                     }
                   }
@@ -6048,7 +6879,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "posts_bool_exp",
+                  "name": "PostsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6067,7 +6898,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "posts",
+                    "name": "Posts",
                     "ofType": null
                   }
                 }
@@ -6081,7 +6912,7 @@
             "description": "fetch data from the table: \"seos\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -6091,7 +6922,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "seos_select_column",
+                      "name": "SeosSelectColumn",
                       "ofType": null
                     }
                   }
@@ -6125,7 +6956,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -6135,7 +6966,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "seos_order_by",
+                      "name": "SeosOrderBy",
                       "ofType": null
                     }
                   }
@@ -6149,7 +6980,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "seos_bool_exp",
+                  "name": "SeosBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6168,7 +6999,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "seos",
+                    "name": "Seos",
                     "ofType": null
                   }
                 }
@@ -6178,7 +7009,7 @@
             "deprecationReason": null
           },
           {
-            "name": "seos_by_pk",
+            "name": "seosByPk",
             "description": "fetch data from the table: \"seos\" using primary key columns",
             "args": [
               {
@@ -6200,18 +7031,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "seos",
+              "name": "Seos",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "seos_stream",
+            "name": "seosStream",
             "description": "fetch data from the table in a streaming manner: \"seos\"",
             "args": [
               {
-                "name": "batch_size",
+                "name": "batchSize",
                 "description": "maximum number of rows returned in a single batch",
                 "type": {
                   "kind": "NON_NULL",
@@ -6237,7 +7068,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "seos_stream_cursor_input",
+                      "name": "SeosStreamCursorInput",
                       "ofType": null
                     }
                   }
@@ -6251,7 +7082,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "seos_bool_exp",
+                  "name": "SeosBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6270,7 +7101,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "seos",
+                    "name": "Seos",
                     "ofType": null
                   }
                 }
@@ -6284,7 +7115,7 @@
             "description": "fetch data from the table: \"tags\"",
             "args": [
               {
-                "name": "distinct_on",
+                "name": "distinctOn",
                 "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
@@ -6294,7 +7125,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "tags_select_column",
+                      "name": "TagsSelectColumn",
                       "ofType": null
                     }
                   }
@@ -6328,7 +7159,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "order_by",
+                "name": "orderBy",
                 "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
@@ -6338,7 +7169,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "tags_order_by",
+                      "name": "TagsOrderBy",
                       "ofType": null
                     }
                   }
@@ -6352,7 +7183,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "tags_bool_exp",
+                  "name": "TagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6371,7 +7202,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "tags",
+                    "name": "Tags",
                     "ofType": null
                   }
                 }
@@ -6381,7 +7212,7 @@
             "deprecationReason": null
           },
           {
-            "name": "tags_by_pk",
+            "name": "tagsByPk",
             "description": "fetch data from the table: \"tags\" using primary key columns",
             "args": [
               {
@@ -6403,18 +7234,18 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "tags",
+              "name": "Tags",
               "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "tags_stream",
+            "name": "tagsStream",
             "description": "fetch data from the table in a streaming manner: \"tags\"",
             "args": [
               {
-                "name": "batch_size",
+                "name": "batchSize",
                 "description": "maximum number of rows returned in a single batch",
                 "type": {
                   "kind": "NON_NULL",
@@ -6440,7 +7271,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "tags_stream_cursor_input",
+                      "name": "TagsStreamCursorInput",
                       "ofType": null
                     }
                   }
@@ -6454,7 +7285,7 @@
                 "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "tags_bool_exp",
+                  "name": "TagsBoolExp",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6473,7 +7304,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "tags",
+                    "name": "Tags",
                     "ofType": null
                   }
                 }
@@ -6485,567 +7316,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "tags",
-        "description": "タグ",
-        "fields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "説明文",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "タグID",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "uuid",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags",
-            "description": "An array relationship",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "post_tags_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "post_tags_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "post_tags_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "post_tags",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": "タグ",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "tags_bool_exp",
-        "description": "Boolean expression to filter rows from the table \"tags\". All fields are combined with a logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_and",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "tags_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_not",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "tags_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_or",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "tags_bool_exp",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "uuid_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "timestamptz_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "tags_order_by",
-        "description": "Ordering options when selecting data from \"tags\".",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "post_tags_aggregate",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "post_tags_aggregate_order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "tags_select_column",
-        "description": "select columns of table \"tags\"",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "created_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "tags_stream_cursor_input",
-        "description": "Streaming cursor of the table \"tags\"",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "initial_value",
-            "description": "Stream column input with initial value",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "tags_stream_cursor_value_input",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ordering",
-            "description": "cursor ordering",
-            "type": {
-              "kind": "ENUM",
-              "name": "cursor_ordering",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "tags_stream_cursor_value_input",
-        "description": "Initial value of the column from where the streaming should start",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "created_at",
-            "description": "作成日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "説明文",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "タグID",
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tag",
-            "description": "タグ",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": "更新日時",
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7060,281 +7330,11 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "timestamptz_comparison_exp",
-        "description": "Boolean expression to compare columns of type \"timestamptz\". All fields are combined with logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_eq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_in",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "timestamptz",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_is_null",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_neq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_nin",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "timestamptz",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "SCALAR",
         "name": "uuid",
         "description": null,
         "fields": null,
         "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "uuid_comparison_exp",
-        "description": "Boolean expression to compare columns of type \"uuid\". All fields are combined with logical 'AND'.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_eq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_gte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_in",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "uuid",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_is_null",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_lte",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_neq",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "uuid",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_nin",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "uuid",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null

--- a/apps/frontend/src/app/_features/post/components/hero-image.tsx
+++ b/apps/frontend/src/app/_features/post/components/hero-image.tsx
@@ -8,13 +8,11 @@ interface Props {
   heroImage?: string;
   heroText?: string | null;
   title: string;
-  publishedAt: string;
+  publishedAt: Date | null | undefined;
   tags: string[];
 }
 
 export const HeroImage = ({ heroImage, heroText, title, publishedAt, tags }: Props): JSX.Element => {
-  const localPublishedAt = formatDateEn(utcToJstTime(new Date(publishedAt)));
-
   return (
     <div className="relative h-52 overflow-hidden md:h-72 lg:h-80">
       {/* Image */}
@@ -51,7 +49,7 @@ export const HeroImage = ({ heroImage, heroText, title, publishedAt, tags }: Pro
           {/* Update Date */}
           <div className="flex items-center gap-2 text-sm md:text-base">
             <CalendarIcon />
-            <time>{localPublishedAt}</time>
+            {publishedAt && <time>{formatDateEn(utcToJstTime(publishedAt))}</time>}
           </div>
 
           {/* Tags */}

--- a/apps/frontend/src/app/_features/post/components/post-card.tsx
+++ b/apps/frontend/src/app/_features/post/components/post-card.tsx
@@ -8,7 +8,7 @@ interface Props {
   href: string;
   title: string;
   description?: string | undefined | null;
-  publishedAt: string;
+  publishedAt: Date | null | undefined;
   heroImage: string;
   heroText?: string | undefined | null;
 }
@@ -39,7 +39,7 @@ export const PostCard: React.FC<Props> = ({ href, title, description, publishedA
           {description && <div className="mt-1 line-clamp-2 text-gray-500 dark:text-gray-400">{description}</div>}
 
           <div className="mt-3 text-sm text-gray-400 dark:text-gray-500">
-            <time>{formatDateEn(utcToJstTime(new Date(publishedAt)))}</time>
+            {publishedAt && <time>{formatDateEn(utcToJstTime(publishedAt))}</time>}
           </div>
         </div>
       </Link>

--- a/apps/frontend/src/app/_features/post/components/post-content.tsx
+++ b/apps/frontend/src/app/_features/post/components/post-content.tsx
@@ -7,7 +7,7 @@ import { CalendarIcon } from "@radix-ui/react-icons";
 import { MarkdownRenderer } from "@tatsutakeinjp/ui/markdown";
 
 interface PostContentProps {
-  post: PostQuery["posts_by_pk"];
+  post: PostQuery["postsByPk"];
 }
 
 export const PostContent: (props: PostContentProps) => JSX.Element = ({ post }) => {
@@ -21,8 +21,8 @@ export const PostContent: (props: PostContentProps) => JSX.Element = ({ post }) 
         heroImage={post.coverImage?.url ?? "/images/hero-default.png"}
         heroText={null}
         title={post.title}
-        publishedAt={String(post.published_at)}
-        tags={[]}
+        publishedAt={post.publishedAt}
+        tags={post.post_tags.map((tag) => tag.tag.tag)}
       />
 
       <article className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6 md:px-8">
@@ -32,7 +32,7 @@ export const PostContent: (props: PostContentProps) => JSX.Element = ({ post }) 
             <span className="inline-flex items-center text-gray-400 dark:text-gray-500">
               <CalendarIcon className="mr-2 h-4" />
               {}
-              <time>{formatDateEn(utcToJstTime(new Date(String(post.published_at))), "LLL d, yyyy")}</time>
+              {post.publishedAt && <time>{formatDateEn(utcToJstTime(post.publishedAt), "LLL d, yyyy")}</time>}
             </span>
           </div>
 

--- a/apps/frontend/src/app/_features/post/gql/index.tsx
+++ b/apps/frontend/src/app/_features/post/gql/index.tsx
@@ -5,11 +5,11 @@ import { gql } from "@/gql";
  */
 export const getPostsQuery = gql(/* GraphQL */ `
   query Posts($now: timestamptz!) {
-    posts(order_by: { published_at: desc }, where: { published_at: { _lte: $now } }) {
+    posts(orderBy: { publishedAt: DESC }, where: { publishedAt: { _lte: $now } }) {
       id
       title
       excerpt
-      published_at
+      publishedAt
       coverImage {
         url
       }
@@ -22,7 +22,7 @@ export const getPostsQuery = gql(/* GraphQL */ `
  */
 export const getPostIdsQuery = gql(/* GraphQL */ `
   query PostIds($now: timestamptz!) {
-    posts(where: { published_at: { _lte: $now } }) {
+    posts(where: { publishedAt: { _lte: $now } }) {
       id
     }
   }
@@ -33,7 +33,7 @@ export const getPostIdsQuery = gql(/* GraphQL */ `
  */
 export const getPostMetadataQuery = gql(/* GraphQL */ `
   query PostMetadata($id: uuid!) {
-    posts_by_pk(id: $id) {
+    postsByPk(id: $id) {
       title
       excerpt
     }
@@ -45,10 +45,10 @@ export const getPostMetadataQuery = gql(/* GraphQL */ `
  */
 export const getPostQuery = gql(/* GraphQL */ `
   query Post($id: uuid!) {
-    posts_by_pk(id: $id) {
+    postsByPk(id: $id) {
       title
       excerpt
-      published_at
+      publishedAt
       coverImage {
         url
       }

--- a/apps/frontend/src/app/posts/[id]/page.tsx
+++ b/apps/frontend/src/app/posts/[id]/page.tsx
@@ -26,7 +26,7 @@ export async function generateStaticParams(): Promise<PageProps["params"][]> {
       ),
   });
   const posts = data?.posts ?? [];
-  return posts.map((post) => ({ id: String(post.id) }));
+  return posts.map((post) => ({ id: post.id }));
 }
 
 // @see https://nextjs.org/docs/app/building-your-application/data-fetching/revalidating
@@ -35,7 +35,7 @@ export const revalidate = 43200;
 
 export default async function PostPage({ params: { id } }: PageProps): Promise<JSX.Element> {
   try {
-    const { posts_by_pk: post } = await queryClient.fetchQuery({
+    const { postsByPk: post } = await queryClient.fetchQuery({
       queryKey: ["post", id],
       queryFn: async () => {
         try {
@@ -47,7 +47,7 @@ export default async function PostPage({ params: { id } }: PageProps): Promise<J
           );
         } catch (error) {
           return {
-            posts_by_pk: null,
+            postsByPk: null,
           };
         }
       },
@@ -65,7 +65,7 @@ export default async function PostPage({ params: { id } }: PageProps): Promise<J
 
 // @see https://nextjs.org/docs/app/api-reference/functions/generate-metadata#generatemetadata-function
 export async function generateMetadata({ params: { id } }: PageProps): Promise<Metadata> {
-  const { posts_by_pk: post } = await queryClient.fetchQuery({
+  const { postsByPk: post } = await queryClient.fetchQuery({
     queryKey: ["post-metadata", id],
     queryFn: async () => {
       try {
@@ -77,7 +77,7 @@ export async function generateMetadata({ params: { id } }: PageProps): Promise<M
         );
       } catch (e) {
         return {
-          posts_by_pk: null,
+          postsByPk: null,
         };
       }
     },

--- a/apps/frontend/src/app/posts/page.tsx
+++ b/apps/frontend/src/app/posts/page.tsx
@@ -28,13 +28,13 @@ export default async function PostListPage(): Promise<JSX.Element> {
   });
   const posts = data?.posts ?? [];
 
-  const postList = posts.map(({ id, title, excerpt, published_at, coverImage }) => (
+  const postList = posts.map(({ id, title, excerpt, publishedAt, coverImage }) => (
     <PostCard
-      key={String(id)}
+      key={id}
       href={`/posts/${id}`}
       title={title}
       description={excerpt}
-      publishedAt={String(published_at)}
+      publishedAt={publishedAt}
       heroImage={coverImage?.url ?? "/images/hero-default.png"}
       heroText={null}
     />

--- a/apps/frontend/src/gql/gql.ts
+++ b/apps/frontend/src/gql/gql.ts
@@ -14,13 +14,13 @@ import * as types from "./graphql";
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
-  "\n  query Posts($now: timestamptz!) {\n    posts(order_by: { published_at: desc }, where: { published_at: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n    }\n  }\n":
+  "\n  query Posts($now: timestamptz!) {\n    posts(orderBy: { publishedAt: DESC }, where: { publishedAt: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n    }\n  }\n":
     types.PostsDocument,
-  "\n  query PostIds($now: timestamptz!) {\n    posts(where: { published_at: { _lte: $now } }) {\n      id\n    }\n  }\n":
+  "\n  query PostIds($now: timestamptz!) {\n    posts(where: { publishedAt: { _lte: $now } }) {\n      id\n    }\n  }\n":
     types.PostIdsDocument,
-  "\n  query PostMetadata($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n    }\n  }\n":
+  "\n  query PostMetadata($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n    }\n  }\n":
     types.PostMetadataDocument,
-  "\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n":
+  "\n  query Post($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n":
     types.PostDocument,
 };
 
@@ -42,26 +42,26 @@ export function gql(source: string): unknown;
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: "\n  query Posts($now: timestamptz!) {\n    posts(order_by: { published_at: desc }, where: { published_at: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n    }\n  }\n",
-): (typeof documents)["\n  query Posts($now: timestamptz!) {\n    posts(order_by: { published_at: desc }, where: { published_at: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n    }\n  }\n"];
+  source: "\n  query Posts($now: timestamptz!) {\n    posts(orderBy: { publishedAt: DESC }, where: { publishedAt: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n    }\n  }\n",
+): (typeof documents)["\n  query Posts($now: timestamptz!) {\n    posts(orderBy: { publishedAt: DESC }, where: { publishedAt: { _lte: $now } }) {\n      id\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: "\n  query PostIds($now: timestamptz!) {\n    posts(where: { published_at: { _lte: $now } }) {\n      id\n    }\n  }\n",
-): (typeof documents)["\n  query PostIds($now: timestamptz!) {\n    posts(where: { published_at: { _lte: $now } }) {\n      id\n    }\n  }\n"];
+  source: "\n  query PostIds($now: timestamptz!) {\n    posts(where: { publishedAt: { _lte: $now } }) {\n      id\n    }\n  }\n",
+): (typeof documents)["\n  query PostIds($now: timestamptz!) {\n    posts(where: { publishedAt: { _lte: $now } }) {\n      id\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: "\n  query PostMetadata($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n    }\n  }\n",
-): (typeof documents)["\n  query PostMetadata($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n    }\n  }\n"];
+  source: "\n  query PostMetadata($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n    }\n  }\n",
+): (typeof documents)["\n  query PostMetadata($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: "\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n",
-): (typeof documents)["\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      excerpt\n      published_at\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n"];
+  source: "\n  query Post($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n",
+): (typeof documents)["\n  query Post($id: uuid!) {\n    postsByPk(id: $id) {\n      title\n      excerpt\n      publishedAt\n      coverImage {\n        url\n      }\n      content\n      post_tags {\n        tag {\n          tag\n        }\n      }\n    }\n  }\n"];
 
 export function gql(source: string) {
   return (documents as any)[source] ?? {};

--- a/apps/frontend/src/gql/graphql.ts
+++ b/apps/frontend/src/gql/graphql.ts
@@ -20,17 +20,551 @@ export type Scalars = {
   uuid: { input: string; output: string };
 };
 
+/** アセット */
+export type Assets = {
+  __typename?: "Assets";
+  /** 作成日時 */
+  createdAt: Scalars["timestamptz"]["output"];
+  /** 説明文 */
+  fileName: Scalars["String"]["output"];
+  /** 高さ */
+  height: Scalars["smallint"]["output"];
+  /** アセットID */
+  id: Scalars["uuid"]["output"];
+  /** MimeType */
+  mimeType: Scalars["String"]["output"];
+  /** An array relationship */
+  posts: Array<Posts>;
+  /** ファイルサイズ */
+  size: Scalars["Int"]["output"];
+  /** 更新日時 */
+  updatedAt: Scalars["timestamptz"]["output"];
+  /** アセットソース */
+  url: Scalars["String"]["output"];
+  /** 幅 */
+  width: Scalars["smallint"]["output"];
+};
+
+/** アセット */
+export type AssetsPostsArgs = {
+  distinctOn?: InputMaybe<Array<PostsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
+};
+
+/** Boolean expression to filter rows from the table "assets". All fields are combined with a logical 'AND'. */
+export type AssetsBoolExp = {
+  _and?: InputMaybe<Array<AssetsBoolExp>>;
+  _not?: InputMaybe<AssetsBoolExp>;
+  _or?: InputMaybe<Array<AssetsBoolExp>>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
+  fileName?: InputMaybe<StringComparisonExp>;
+  height?: InputMaybe<SmallintComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  mimeType?: InputMaybe<StringComparisonExp>;
+  posts?: InputMaybe<PostsBoolExp>;
+  size?: InputMaybe<IntComparisonExp>;
+  updatedAt?: InputMaybe<TimestamptzComparisonExp>;
+  url?: InputMaybe<StringComparisonExp>;
+  width?: InputMaybe<SmallintComparisonExp>;
+};
+
+/** Ordering options when selecting data from "assets". */
+export type AssetsOrderBy = {
+  createdAt?: InputMaybe<OrderBy>;
+  fileName?: InputMaybe<OrderBy>;
+  height?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  mimeType?: InputMaybe<OrderBy>;
+  postsAggregate?: InputMaybe<PostsAggregateOrderBy>;
+  size?: InputMaybe<OrderBy>;
+  updatedAt?: InputMaybe<OrderBy>;
+  url?: InputMaybe<OrderBy>;
+  width?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "assets" */
+export enum AssetsSelectColumn {
+  /** column name */
+  CREATEDAT = "createdAt",
+  /** column name */
+  FILENAME = "fileName",
+  /** column name */
+  HEIGHT = "height",
+  /** column name */
+  ID = "id",
+  /** column name */
+  MIMETYPE = "mimeType",
+  /** column name */
+  SIZE = "size",
+  /** column name */
+  UPDATEDAT = "updatedAt",
+  /** column name */
+  URL = "url",
+  /** column name */
+  WIDTH = "width",
+}
+
+/** Streaming cursor of the table "assets" */
+export type AssetsStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: AssetsStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type AssetsStreamCursorValueInput = {
+  /** 作成日時 */
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** 説明文 */
+  fileName?: InputMaybe<Scalars["String"]["input"]>;
+  /** 高さ */
+  height?: InputMaybe<Scalars["smallint"]["input"]>;
+  /** アセットID */
+  id?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** MimeType */
+  mimeType?: InputMaybe<Scalars["String"]["input"]>;
+  /** ファイルサイズ */
+  size?: InputMaybe<Scalars["Int"]["input"]>;
+  /** 更新日時 */
+  updatedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** アセットソース */
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  /** 幅 */
+  width?: InputMaybe<Scalars["smallint"]["input"]>;
+};
+
+/** ordering argument of a cursor */
+export enum CursorOrdering {
+  /** ascending ordering of the cursor */
+  ASC = "ASC",
+  /** descending ordering of the cursor */
+  DESC = "DESC",
+}
+
 /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
 export type IntComparisonExp = {
   _eq?: InputMaybe<Scalars["Int"]["input"]>;
   _gt?: InputMaybe<Scalars["Int"]["input"]>;
   _gte?: InputMaybe<Scalars["Int"]["input"]>;
   _in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
   _lt?: InputMaybe<Scalars["Int"]["input"]>;
   _lte?: InputMaybe<Scalars["Int"]["input"]>;
   _neq?: InputMaybe<Scalars["Int"]["input"]>;
   _nin?: InputMaybe<Array<Scalars["Int"]["input"]>>;
+};
+
+/** column ordering options */
+export enum OrderBy {
+  /** in ascending order, nulls last */
+  ASC = "ASC",
+  /** in ascending order, nulls first */
+  ASC_NULLS_FIRST = "ASC_NULLS_FIRST",
+  /** in ascending order, nulls last */
+  ASC_NULLS_LAST = "ASC_NULLS_LAST",
+  /** in descending order, nulls first */
+  DESC = "DESC",
+  /** in descending order, nulls first */
+  DESC_NULLS_FIRST = "DESC_NULLS_FIRST",
+  /** in descending order, nulls last */
+  DESC_NULLS_LAST = "DESC_NULLS_LAST",
+}
+
+/** ポストとタグの関連付け */
+export type PostTags = {
+  __typename?: "PostTags";
+  /** An object relationship */
+  post: Posts;
+  /** ポストID */
+  postId: Scalars["uuid"]["output"];
+  /** An object relationship */
+  tag: Tags;
+  /** タグID */
+  tagId: Scalars["uuid"]["output"];
+};
+
+/** order by aggregate values of table "post_tags" */
+export type PostTagsAggregateOrderBy = {
+  count?: InputMaybe<OrderBy>;
+  max?: InputMaybe<PostTagsMaxOrderBy>;
+  min?: InputMaybe<PostTagsMinOrderBy>;
+};
+
+/** Boolean expression to filter rows from the table "post_tags". All fields are combined with a logical 'AND'. */
+export type PostTagsBoolExp = {
+  _and?: InputMaybe<Array<PostTagsBoolExp>>;
+  _not?: InputMaybe<PostTagsBoolExp>;
+  _or?: InputMaybe<Array<PostTagsBoolExp>>;
+  post?: InputMaybe<PostsBoolExp>;
+  postId?: InputMaybe<UuidComparisonExp>;
+  tag?: InputMaybe<TagsBoolExp>;
+  tagId?: InputMaybe<UuidComparisonExp>;
+};
+
+/** order by max() on columns of table "post_tags" */
+export type PostTagsMaxOrderBy = {
+  /** ポストID */
+  postId?: InputMaybe<OrderBy>;
+  /** タグID */
+  tagId?: InputMaybe<OrderBy>;
+};
+
+/** order by min() on columns of table "post_tags" */
+export type PostTagsMinOrderBy = {
+  /** ポストID */
+  postId?: InputMaybe<OrderBy>;
+  /** タグID */
+  tagId?: InputMaybe<OrderBy>;
+};
+
+/** Ordering options when selecting data from "post_tags". */
+export type PostTagsOrderBy = {
+  post?: InputMaybe<PostsOrderBy>;
+  postId?: InputMaybe<OrderBy>;
+  tag?: InputMaybe<TagsOrderBy>;
+  tagId?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "post_tags" */
+export enum PostTagsSelectColumn {
+  /** column name */
+  POSTID = "postId",
+  /** column name */
+  TAGID = "tagId",
+}
+
+/** Streaming cursor of the table "post_tags" */
+export type PostTagsStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: PostTagsStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type PostTagsStreamCursorValueInput = {
+  /** ポストID */
+  postId?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** タグID */
+  tagId?: InputMaybe<Scalars["uuid"]["input"]>;
+};
+
+/** ポスト */
+export type Posts = {
+  __typename?: "Posts";
+  /** 内容 */
+  content: Scalars["String"]["output"];
+  /** An object relationship */
+  coverImage?: Maybe<Assets>;
+  /** カバー画像 */
+  coverImageId?: Maybe<Scalars["uuid"]["output"]>;
+  /** 作成日時 */
+  createdAt: Scalars["timestamptz"]["output"];
+  /** 削除日時 */
+  deletedAt?: Maybe<Scalars["timestamptz"]["output"]>;
+  /** 抜粋 */
+  excerpt: Scalars["String"]["output"];
+  /** ポスト ID */
+  id: Scalars["uuid"]["output"];
+  /** An array relationship */
+  post_tags: Array<PostTags>;
+  /** 公開日時 */
+  publishedAt?: Maybe<Scalars["timestamptz"]["output"]>;
+  /** An object relationship */
+  seo?: Maybe<Seos>;
+  /** SEO */
+  seoId?: Maybe<Scalars["uuid"]["output"]>;
+  /** ラベル文字列 */
+  slug: Scalars["String"]["output"];
+  /** タイトル */
+  title: Scalars["String"]["output"];
+  /** 更新日時 */
+  updatedAt: Scalars["timestamptz"]["output"];
+};
+
+/** ポスト */
+export type PostsPostTagsArgs = {
+  distinctOn?: InputMaybe<Array<PostTagsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
+};
+
+/** order by aggregate values of table "posts" */
+export type PostsAggregateOrderBy = {
+  count?: InputMaybe<OrderBy>;
+  max?: InputMaybe<PostsMaxOrderBy>;
+  min?: InputMaybe<PostsMinOrderBy>;
+};
+
+/** Boolean expression to filter rows from the table "posts". All fields are combined with a logical 'AND'. */
+export type PostsBoolExp = {
+  _and?: InputMaybe<Array<PostsBoolExp>>;
+  _not?: InputMaybe<PostsBoolExp>;
+  _or?: InputMaybe<Array<PostsBoolExp>>;
+  content?: InputMaybe<StringComparisonExp>;
+  coverImage?: InputMaybe<AssetsBoolExp>;
+  coverImageId?: InputMaybe<UuidComparisonExp>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
+  deletedAt?: InputMaybe<TimestamptzComparisonExp>;
+  excerpt?: InputMaybe<StringComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  post_tags?: InputMaybe<PostTagsBoolExp>;
+  publishedAt?: InputMaybe<TimestamptzComparisonExp>;
+  seo?: InputMaybe<SeosBoolExp>;
+  seoId?: InputMaybe<UuidComparisonExp>;
+  slug?: InputMaybe<StringComparisonExp>;
+  title?: InputMaybe<StringComparisonExp>;
+  updatedAt?: InputMaybe<TimestamptzComparisonExp>;
+};
+
+/** order by max() on columns of table "posts" */
+export type PostsMaxOrderBy = {
+  /** 内容 */
+  content?: InputMaybe<OrderBy>;
+  /** カバー画像 */
+  coverImageId?: InputMaybe<OrderBy>;
+  /** 作成日時 */
+  createdAt?: InputMaybe<OrderBy>;
+  /** 削除日時 */
+  deletedAt?: InputMaybe<OrderBy>;
+  /** 抜粋 */
+  excerpt?: InputMaybe<OrderBy>;
+  /** ポスト ID */
+  id?: InputMaybe<OrderBy>;
+  /** 公開日時 */
+  publishedAt?: InputMaybe<OrderBy>;
+  /** SEO */
+  seoId?: InputMaybe<OrderBy>;
+  /** ラベル文字列 */
+  slug?: InputMaybe<OrderBy>;
+  /** タイトル */
+  title?: InputMaybe<OrderBy>;
+  /** 更新日時 */
+  updatedAt?: InputMaybe<OrderBy>;
+};
+
+/** order by min() on columns of table "posts" */
+export type PostsMinOrderBy = {
+  /** 内容 */
+  content?: InputMaybe<OrderBy>;
+  /** カバー画像 */
+  coverImageId?: InputMaybe<OrderBy>;
+  /** 作成日時 */
+  createdAt?: InputMaybe<OrderBy>;
+  /** 削除日時 */
+  deletedAt?: InputMaybe<OrderBy>;
+  /** 抜粋 */
+  excerpt?: InputMaybe<OrderBy>;
+  /** ポスト ID */
+  id?: InputMaybe<OrderBy>;
+  /** 公開日時 */
+  publishedAt?: InputMaybe<OrderBy>;
+  /** SEO */
+  seoId?: InputMaybe<OrderBy>;
+  /** ラベル文字列 */
+  slug?: InputMaybe<OrderBy>;
+  /** タイトル */
+  title?: InputMaybe<OrderBy>;
+  /** 更新日時 */
+  updatedAt?: InputMaybe<OrderBy>;
+};
+
+/** Ordering options when selecting data from "posts". */
+export type PostsOrderBy = {
+  content?: InputMaybe<OrderBy>;
+  coverImage?: InputMaybe<AssetsOrderBy>;
+  coverImageId?: InputMaybe<OrderBy>;
+  createdAt?: InputMaybe<OrderBy>;
+  deletedAt?: InputMaybe<OrderBy>;
+  excerpt?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  post_tagsAggregate?: InputMaybe<PostTagsAggregateOrderBy>;
+  publishedAt?: InputMaybe<OrderBy>;
+  seo?: InputMaybe<SeosOrderBy>;
+  seoId?: InputMaybe<OrderBy>;
+  slug?: InputMaybe<OrderBy>;
+  title?: InputMaybe<OrderBy>;
+  updatedAt?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "posts" */
+export enum PostsSelectColumn {
+  /** column name */
+  CONTENT = "content",
+  /** column name */
+  COVERIMAGEID = "coverImageId",
+  /** column name */
+  CREATEDAT = "createdAt",
+  /** column name */
+  DELETEDAT = "deletedAt",
+  /** column name */
+  EXCERPT = "excerpt",
+  /** column name */
+  ID = "id",
+  /** column name */
+  PUBLISHEDAT = "publishedAt",
+  /** column name */
+  SEOID = "seoId",
+  /** column name */
+  SLUG = "slug",
+  /** column name */
+  TITLE = "title",
+  /** column name */
+  UPDATEDAT = "updatedAt",
+}
+
+/** Streaming cursor of the table "posts" */
+export type PostsStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: PostsStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type PostsStreamCursorValueInput = {
+  /** 内容 */
+  content?: InputMaybe<Scalars["String"]["input"]>;
+  /** カバー画像 */
+  coverImageId?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** 作成日時 */
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** 削除日時 */
+  deletedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** 抜粋 */
+  excerpt?: InputMaybe<Scalars["String"]["input"]>;
+  /** ポスト ID */
+  id?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** 公開日時 */
+  publishedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** SEO */
+  seoId?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** ラベル文字列 */
+  slug?: InputMaybe<Scalars["String"]["input"]>;
+  /** タイトル */
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  /** 更新日時 */
+  updatedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** SEO */
+export type Seos = {
+  __typename?: "Seos";
+  /** 作成日時 */
+  createdAt: Scalars["timestamptz"]["output"];
+  /** 削除日時 */
+  deletedAt?: Maybe<Scalars["timestamptz"]["output"]>;
+  /** 説明文 */
+  description: Scalars["String"]["output"];
+  /** SEO ID */
+  id: Scalars["uuid"]["output"];
+  /** カスタム OG 画像 URL ( 1280✕720 ) */
+  ogImageUrl?: Maybe<Scalars["String"]["output"]>;
+  /** An array relationship */
+  posts: Array<Posts>;
+  /** タイトル */
+  title: Scalars["String"]["output"];
+  /** 更新日時 */
+  updatedAt: Scalars["timestamptz"]["output"];
+};
+
+/** SEO */
+export type SeosPostsArgs = {
+  distinctOn?: InputMaybe<Array<PostsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
+};
+
+/** Boolean expression to filter rows from the table "seos". All fields are combined with a logical 'AND'. */
+export type SeosBoolExp = {
+  _and?: InputMaybe<Array<SeosBoolExp>>;
+  _not?: InputMaybe<SeosBoolExp>;
+  _or?: InputMaybe<Array<SeosBoolExp>>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
+  deletedAt?: InputMaybe<TimestamptzComparisonExp>;
+  description?: InputMaybe<StringComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  ogImageUrl?: InputMaybe<StringComparisonExp>;
+  posts?: InputMaybe<PostsBoolExp>;
+  title?: InputMaybe<StringComparisonExp>;
+  updatedAt?: InputMaybe<TimestamptzComparisonExp>;
+};
+
+/** Ordering options when selecting data from "seos". */
+export type SeosOrderBy = {
+  createdAt?: InputMaybe<OrderBy>;
+  deletedAt?: InputMaybe<OrderBy>;
+  description?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  ogImageUrl?: InputMaybe<OrderBy>;
+  postsAggregate?: InputMaybe<PostsAggregateOrderBy>;
+  title?: InputMaybe<OrderBy>;
+  updatedAt?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "seos" */
+export enum SeosSelectColumn {
+  /** column name */
+  CREATEDAT = "createdAt",
+  /** column name */
+  DELETEDAT = "deletedAt",
+  /** column name */
+  DESCRIPTION = "description",
+  /** column name */
+  ID = "id",
+  /** column name */
+  OGIMAGEURL = "ogImageUrl",
+  /** column name */
+  TITLE = "title",
+  /** column name */
+  UPDATEDAT = "updatedAt",
+}
+
+/** Streaming cursor of the table "seos" */
+export type SeosStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: SeosStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type SeosStreamCursorValueInput = {
+  /** 作成日時 */
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** 削除日時 */
+  deletedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  /** 説明文 */
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  /** SEO ID */
+  id?: InputMaybe<Scalars["uuid"]["input"]>;
+  /** カスタム OG 画像 URL ( 1280✕720 ) */
+  ogImageUrl?: InputMaybe<Scalars["String"]["input"]>;
+  /** タイトル */
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  /** 更新日時 */
+  updatedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+};
+
+/** Boolean expression to compare columns of type "smallint". All fields are combined with logical 'AND'. */
+export type SmallintComparisonExp = {
+  _eq?: InputMaybe<Scalars["smallint"]["input"]>;
+  _gt?: InputMaybe<Scalars["smallint"]["input"]>;
+  _gte?: InputMaybe<Scalars["smallint"]["input"]>;
+  _in?: InputMaybe<Array<Scalars["smallint"]["input"]>>;
+  _isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _lt?: InputMaybe<Scalars["smallint"]["input"]>;
+  _lte?: InputMaybe<Scalars["smallint"]["input"]>;
+  _neq?: InputMaybe<Scalars["smallint"]["input"]>;
+  _nin?: InputMaybe<Array<Scalars["smallint"]["input"]>>;
 };
 
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -43,7 +577,7 @@ export type StringComparisonExp = {
   _in?: InputMaybe<Array<Scalars["String"]["input"]>>;
   /** does the column match the given POSIX regular expression, case insensitive */
   _iregex?: InputMaybe<Scalars["String"]["input"]>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** does the column match the given pattern */
   _like?: InputMaybe<Scalars["String"]["input"]>;
   _lt?: InputMaybe<Scalars["String"]["input"]>;
@@ -66,755 +600,11 @@ export type StringComparisonExp = {
   _similar?: InputMaybe<Scalars["String"]["input"]>;
 };
 
-/** アセット */
-export type Assets = {
-  __typename?: "assets";
-  /** 作成日時 */
-  created_at: Scalars["timestamptz"]["output"];
-  /** 説明文 */
-  file_name: Scalars["String"]["output"];
-  /** 高さ */
-  height: Scalars["smallint"]["output"];
-  /** アセットID */
-  id: Scalars["uuid"]["output"];
-  /** MimeType */
-  mime_type: Scalars["String"]["output"];
-  /** An array relationship */
-  posts: Array<Posts>;
-  /** ファイルサイズ */
-  size: Scalars["Int"]["output"];
-  /** 更新日時 */
-  updated_at: Scalars["timestamptz"]["output"];
-  /** アセットソース */
-  url: Scalars["String"]["output"];
-  /** 幅 */
-  width: Scalars["smallint"]["output"];
-};
-
-/** アセット */
-export type AssetsPostsArgs = {
-  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostsOrderBy>>;
-  where?: InputMaybe<PostsBoolExp>;
-};
-
-/** Boolean expression to filter rows from the table "assets". All fields are combined with a logical 'AND'. */
-export type AssetsBoolExp = {
-  _and?: InputMaybe<Array<AssetsBoolExp>>;
-  _not?: InputMaybe<AssetsBoolExp>;
-  _or?: InputMaybe<Array<AssetsBoolExp>>;
-  created_at?: InputMaybe<TimestamptzComparisonExp>;
-  file_name?: InputMaybe<StringComparisonExp>;
-  height?: InputMaybe<SmallintComparisonExp>;
-  id?: InputMaybe<UuidComparisonExp>;
-  mime_type?: InputMaybe<StringComparisonExp>;
-  posts?: InputMaybe<PostsBoolExp>;
-  size?: InputMaybe<IntComparisonExp>;
-  updated_at?: InputMaybe<TimestamptzComparisonExp>;
-  url?: InputMaybe<StringComparisonExp>;
-  width?: InputMaybe<SmallintComparisonExp>;
-};
-
-/** Ordering options when selecting data from "assets". */
-export type AssetsOrderBy = {
-  created_at?: InputMaybe<OrderBy>;
-  file_name?: InputMaybe<OrderBy>;
-  height?: InputMaybe<OrderBy>;
-  id?: InputMaybe<OrderBy>;
-  mime_type?: InputMaybe<OrderBy>;
-  posts_aggregate?: InputMaybe<PostsAggregateOrderBy>;
-  size?: InputMaybe<OrderBy>;
-  updated_at?: InputMaybe<OrderBy>;
-  url?: InputMaybe<OrderBy>;
-  width?: InputMaybe<OrderBy>;
-};
-
-/** select columns of table "assets" */
-export enum AssetsSelectColumn {
-  /** column name */
-  CREATED_AT = "created_at",
-  /** column name */
-  FILE_NAME = "file_name",
-  /** column name */
-  HEIGHT = "height",
-  /** column name */
-  ID = "id",
-  /** column name */
-  MIME_TYPE = "mime_type",
-  /** column name */
-  SIZE = "size",
-  /** column name */
-  UPDATED_AT = "updated_at",
-  /** column name */
-  URL = "url",
-  /** column name */
-  WIDTH = "width",
-}
-
-/** Streaming cursor of the table "assets" */
-export type AssetsStreamCursorInput = {
-  /** Stream column input with initial value */
-  initial_value: AssetsStreamCursorValueInput;
-  /** cursor ordering */
-  ordering?: InputMaybe<CursorOrdering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type AssetsStreamCursorValueInput = {
-  /** 作成日時 */
-  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** 説明文 */
-  file_name?: InputMaybe<Scalars["String"]["input"]>;
-  /** 高さ */
-  height?: InputMaybe<Scalars["smallint"]["input"]>;
-  /** アセットID */
-  id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** MimeType */
-  mime_type?: InputMaybe<Scalars["String"]["input"]>;
-  /** ファイルサイズ */
-  size?: InputMaybe<Scalars["Int"]["input"]>;
-  /** 更新日時 */
-  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** アセットソース */
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  /** 幅 */
-  width?: InputMaybe<Scalars["smallint"]["input"]>;
-};
-
-/** ordering argument of a cursor */
-export enum CursorOrdering {
-  /** ascending ordering of the cursor */
-  ASC = "ASC",
-  /** descending ordering of the cursor */
-  DESC = "DESC",
-}
-
-/** column ordering options */
-export enum OrderBy {
-  /** in ascending order, nulls last */
-  ASC = "asc",
-  /** in ascending order, nulls first */
-  ASC_NULLS_FIRST = "asc_nulls_first",
-  /** in ascending order, nulls last */
-  ASC_NULLS_LAST = "asc_nulls_last",
-  /** in descending order, nulls first */
-  DESC = "desc",
-  /** in descending order, nulls first */
-  DESC_NULLS_FIRST = "desc_nulls_first",
-  /** in descending order, nulls last */
-  DESC_NULLS_LAST = "desc_nulls_last",
-}
-
-/** ポストとタグの関連付け */
-export type PostTags = {
-  __typename?: "post_tags";
-  /** An object relationship */
-  post: Posts;
-  /** ポストID */
-  post_id: Scalars["uuid"]["output"];
-  /** An object relationship */
-  tag: Tags;
-  /** タグID */
-  tag_id: Scalars["uuid"]["output"];
-};
-
-/** order by aggregate values of table "post_tags" */
-export type PostTagsAggregateOrderBy = {
-  count?: InputMaybe<OrderBy>;
-  max?: InputMaybe<PostTagsMaxOrderBy>;
-  min?: InputMaybe<PostTagsMinOrderBy>;
-};
-
-/** Boolean expression to filter rows from the table "post_tags". All fields are combined with a logical 'AND'. */
-export type PostTagsBoolExp = {
-  _and?: InputMaybe<Array<PostTagsBoolExp>>;
-  _not?: InputMaybe<PostTagsBoolExp>;
-  _or?: InputMaybe<Array<PostTagsBoolExp>>;
-  post?: InputMaybe<PostsBoolExp>;
-  post_id?: InputMaybe<UuidComparisonExp>;
-  tag?: InputMaybe<TagsBoolExp>;
-  tag_id?: InputMaybe<UuidComparisonExp>;
-};
-
-/** order by max() on columns of table "post_tags" */
-export type PostTagsMaxOrderBy = {
-  /** ポストID */
-  post_id?: InputMaybe<OrderBy>;
-  /** タグID */
-  tag_id?: InputMaybe<OrderBy>;
-};
-
-/** order by min() on columns of table "post_tags" */
-export type PostTagsMinOrderBy = {
-  /** ポストID */
-  post_id?: InputMaybe<OrderBy>;
-  /** タグID */
-  tag_id?: InputMaybe<OrderBy>;
-};
-
-/** Ordering options when selecting data from "post_tags". */
-export type PostTagsOrderBy = {
-  post?: InputMaybe<PostsOrderBy>;
-  post_id?: InputMaybe<OrderBy>;
-  tag?: InputMaybe<TagsOrderBy>;
-  tag_id?: InputMaybe<OrderBy>;
-};
-
-/** select columns of table "post_tags" */
-export enum PostTagsSelectColumn {
-  /** column name */
-  POST_ID = "post_id",
-  /** column name */
-  TAG_ID = "tag_id",
-}
-
-/** Streaming cursor of the table "post_tags" */
-export type PostTagsStreamCursorInput = {
-  /** Stream column input with initial value */
-  initial_value: PostTagsStreamCursorValueInput;
-  /** cursor ordering */
-  ordering?: InputMaybe<CursorOrdering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type PostTagsStreamCursorValueInput = {
-  /** ポストID */
-  post_id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** タグID */
-  tag_id?: InputMaybe<Scalars["uuid"]["input"]>;
-};
-
-/** ポスト */
-export type Posts = {
-  __typename?: "posts";
-  /** 内容 */
-  content: Scalars["String"]["output"];
-  /** An object relationship */
-  coverImage?: Maybe<Assets>;
-  /** カバー画像 */
-  cover_image_id?: Maybe<Scalars["uuid"]["output"]>;
-  /** 作成日時 */
-  created_at: Scalars["timestamptz"]["output"];
-  /** 削除日時 */
-  deleted_at?: Maybe<Scalars["timestamptz"]["output"]>;
-  /** 抜粋 */
-  excerpt: Scalars["String"]["output"];
-  /** ポスト ID */
-  id: Scalars["uuid"]["output"];
-  /** An array relationship */
-  post_tags: Array<PostTags>;
-  /** 公開日時 */
-  published_at?: Maybe<Scalars["timestamptz"]["output"]>;
-  /** An object relationship */
-  seo?: Maybe<Seos>;
-  /** SEO */
-  seo_id?: Maybe<Scalars["uuid"]["output"]>;
-  /** ラベル文字列 */
-  slug: Scalars["String"]["output"];
-  /** タイトル */
-  title: Scalars["String"]["output"];
-  /** 更新日時 */
-  updated_at: Scalars["timestamptz"]["output"];
-};
-
-/** ポスト */
-export type PostsPostTagsArgs = {
-  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
-  where?: InputMaybe<PostTagsBoolExp>;
-};
-
-/** order by aggregate values of table "posts" */
-export type PostsAggregateOrderBy = {
-  count?: InputMaybe<OrderBy>;
-  max?: InputMaybe<PostsMaxOrderBy>;
-  min?: InputMaybe<PostsMinOrderBy>;
-};
-
-/** Boolean expression to filter rows from the table "posts". All fields are combined with a logical 'AND'. */
-export type PostsBoolExp = {
-  _and?: InputMaybe<Array<PostsBoolExp>>;
-  _not?: InputMaybe<PostsBoolExp>;
-  _or?: InputMaybe<Array<PostsBoolExp>>;
-  content?: InputMaybe<StringComparisonExp>;
-  coverImage?: InputMaybe<AssetsBoolExp>;
-  cover_image_id?: InputMaybe<UuidComparisonExp>;
-  created_at?: InputMaybe<TimestamptzComparisonExp>;
-  deleted_at?: InputMaybe<TimestamptzComparisonExp>;
-  excerpt?: InputMaybe<StringComparisonExp>;
-  id?: InputMaybe<UuidComparisonExp>;
-  post_tags?: InputMaybe<PostTagsBoolExp>;
-  published_at?: InputMaybe<TimestamptzComparisonExp>;
-  seo?: InputMaybe<SeosBoolExp>;
-  seo_id?: InputMaybe<UuidComparisonExp>;
-  slug?: InputMaybe<StringComparisonExp>;
-  title?: InputMaybe<StringComparisonExp>;
-  updated_at?: InputMaybe<TimestamptzComparisonExp>;
-};
-
-/** order by max() on columns of table "posts" */
-export type PostsMaxOrderBy = {
-  /** 内容 */
-  content?: InputMaybe<OrderBy>;
-  /** カバー画像 */
-  cover_image_id?: InputMaybe<OrderBy>;
-  /** 作成日時 */
-  created_at?: InputMaybe<OrderBy>;
-  /** 削除日時 */
-  deleted_at?: InputMaybe<OrderBy>;
-  /** 抜粋 */
-  excerpt?: InputMaybe<OrderBy>;
-  /** ポスト ID */
-  id?: InputMaybe<OrderBy>;
-  /** 公開日時 */
-  published_at?: InputMaybe<OrderBy>;
-  /** SEO */
-  seo_id?: InputMaybe<OrderBy>;
-  /** ラベル文字列 */
-  slug?: InputMaybe<OrderBy>;
-  /** タイトル */
-  title?: InputMaybe<OrderBy>;
-  /** 更新日時 */
-  updated_at?: InputMaybe<OrderBy>;
-};
-
-/** order by min() on columns of table "posts" */
-export type PostsMinOrderBy = {
-  /** 内容 */
-  content?: InputMaybe<OrderBy>;
-  /** カバー画像 */
-  cover_image_id?: InputMaybe<OrderBy>;
-  /** 作成日時 */
-  created_at?: InputMaybe<OrderBy>;
-  /** 削除日時 */
-  deleted_at?: InputMaybe<OrderBy>;
-  /** 抜粋 */
-  excerpt?: InputMaybe<OrderBy>;
-  /** ポスト ID */
-  id?: InputMaybe<OrderBy>;
-  /** 公開日時 */
-  published_at?: InputMaybe<OrderBy>;
-  /** SEO */
-  seo_id?: InputMaybe<OrderBy>;
-  /** ラベル文字列 */
-  slug?: InputMaybe<OrderBy>;
-  /** タイトル */
-  title?: InputMaybe<OrderBy>;
-  /** 更新日時 */
-  updated_at?: InputMaybe<OrderBy>;
-};
-
-/** Ordering options when selecting data from "posts". */
-export type PostsOrderBy = {
-  content?: InputMaybe<OrderBy>;
-  coverImage?: InputMaybe<AssetsOrderBy>;
-  cover_image_id?: InputMaybe<OrderBy>;
-  created_at?: InputMaybe<OrderBy>;
-  deleted_at?: InputMaybe<OrderBy>;
-  excerpt?: InputMaybe<OrderBy>;
-  id?: InputMaybe<OrderBy>;
-  post_tags_aggregate?: InputMaybe<PostTagsAggregateOrderBy>;
-  published_at?: InputMaybe<OrderBy>;
-  seo?: InputMaybe<SeosOrderBy>;
-  seo_id?: InputMaybe<OrderBy>;
-  slug?: InputMaybe<OrderBy>;
-  title?: InputMaybe<OrderBy>;
-  updated_at?: InputMaybe<OrderBy>;
-};
-
-/** select columns of table "posts" */
-export enum PostsSelectColumn {
-  /** column name */
-  CONTENT = "content",
-  /** column name */
-  COVER_IMAGE_ID = "cover_image_id",
-  /** column name */
-  CREATED_AT = "created_at",
-  /** column name */
-  DELETED_AT = "deleted_at",
-  /** column name */
-  EXCERPT = "excerpt",
-  /** column name */
-  ID = "id",
-  /** column name */
-  PUBLISHED_AT = "published_at",
-  /** column name */
-  SEO_ID = "seo_id",
-  /** column name */
-  SLUG = "slug",
-  /** column name */
-  TITLE = "title",
-  /** column name */
-  UPDATED_AT = "updated_at",
-}
-
-/** Streaming cursor of the table "posts" */
-export type PostsStreamCursorInput = {
-  /** Stream column input with initial value */
-  initial_value: PostsStreamCursorValueInput;
-  /** cursor ordering */
-  ordering?: InputMaybe<CursorOrdering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type PostsStreamCursorValueInput = {
-  /** 内容 */
-  content?: InputMaybe<Scalars["String"]["input"]>;
-  /** カバー画像 */
-  cover_image_id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** 作成日時 */
-  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** 削除日時 */
-  deleted_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** 抜粋 */
-  excerpt?: InputMaybe<Scalars["String"]["input"]>;
-  /** ポスト ID */
-  id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** 公開日時 */
-  published_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** SEO */
-  seo_id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** ラベル文字列 */
-  slug?: InputMaybe<Scalars["String"]["input"]>;
-  /** タイトル */
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  /** 更新日時 */
-  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-};
-
-export type QueryRoot = {
-  __typename?: "query_root";
-  /** fetch data from the table: "assets" */
-  assets: Array<Assets>;
-  /** fetch data from the table: "assets" using primary key columns */
-  assets_by_pk?: Maybe<Assets>;
-  /** An array relationship */
-  post_tags: Array<PostTags>;
-  /** fetch data from the table: "post_tags" using primary key columns */
-  post_tags_by_pk?: Maybe<PostTags>;
-  /** An array relationship */
-  posts: Array<Posts>;
-  /** fetch data from the table: "posts" using primary key columns */
-  posts_by_pk?: Maybe<Posts>;
-  /** fetch data from the table: "seos" */
-  seos: Array<Seos>;
-  /** fetch data from the table: "seos" using primary key columns */
-  seos_by_pk?: Maybe<Seos>;
-  /** fetch data from the table: "tags" */
-  tags: Array<Tags>;
-  /** fetch data from the table: "tags" using primary key columns */
-  tags_by_pk?: Maybe<Tags>;
-};
-
-export type QueryRootAssetsArgs = {
-  distinct_on?: InputMaybe<Array<AssetsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<AssetsOrderBy>>;
-  where?: InputMaybe<AssetsBoolExp>;
-};
-
-export type QueryRootAssetsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type QueryRootPostTagsArgs = {
-  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
-  where?: InputMaybe<PostTagsBoolExp>;
-};
-
-export type QueryRootPostTagsByPkArgs = {
-  post_id: Scalars["uuid"]["input"];
-  tag_id: Scalars["uuid"]["input"];
-};
-
-export type QueryRootPostsArgs = {
-  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostsOrderBy>>;
-  where?: InputMaybe<PostsBoolExp>;
-};
-
-export type QueryRootPostsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type QueryRootSeosArgs = {
-  distinct_on?: InputMaybe<Array<SeosSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<SeosOrderBy>>;
-  where?: InputMaybe<SeosBoolExp>;
-};
-
-export type QueryRootSeosByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type QueryRootTagsArgs = {
-  distinct_on?: InputMaybe<Array<TagsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<TagsOrderBy>>;
-  where?: InputMaybe<TagsBoolExp>;
-};
-
-export type QueryRootTagsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-/** SEO */
-export type Seos = {
-  __typename?: "seos";
-  /** 作成日時 */
-  created_at: Scalars["timestamptz"]["output"];
-  /** 削除日時 */
-  deleted_at?: Maybe<Scalars["timestamptz"]["output"]>;
-  /** 説明文 */
-  description: Scalars["String"]["output"];
-  /** SEO ID */
-  id: Scalars["uuid"]["output"];
-  /** カスタム OG 画像 URL ( 1280✕720 ) */
-  og_image_url?: Maybe<Scalars["String"]["output"]>;
-  /** An array relationship */
-  posts: Array<Posts>;
-  /** タイトル */
-  title: Scalars["String"]["output"];
-  /** 更新日時 */
-  updated_at: Scalars["timestamptz"]["output"];
-};
-
-/** SEO */
-export type SeosPostsArgs = {
-  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostsOrderBy>>;
-  where?: InputMaybe<PostsBoolExp>;
-};
-
-/** Boolean expression to filter rows from the table "seos". All fields are combined with a logical 'AND'. */
-export type SeosBoolExp = {
-  _and?: InputMaybe<Array<SeosBoolExp>>;
-  _not?: InputMaybe<SeosBoolExp>;
-  _or?: InputMaybe<Array<SeosBoolExp>>;
-  created_at?: InputMaybe<TimestamptzComparisonExp>;
-  deleted_at?: InputMaybe<TimestamptzComparisonExp>;
-  description?: InputMaybe<StringComparisonExp>;
-  id?: InputMaybe<UuidComparisonExp>;
-  og_image_url?: InputMaybe<StringComparisonExp>;
-  posts?: InputMaybe<PostsBoolExp>;
-  title?: InputMaybe<StringComparisonExp>;
-  updated_at?: InputMaybe<TimestamptzComparisonExp>;
-};
-
-/** Ordering options when selecting data from "seos". */
-export type SeosOrderBy = {
-  created_at?: InputMaybe<OrderBy>;
-  deleted_at?: InputMaybe<OrderBy>;
-  description?: InputMaybe<OrderBy>;
-  id?: InputMaybe<OrderBy>;
-  og_image_url?: InputMaybe<OrderBy>;
-  posts_aggregate?: InputMaybe<PostsAggregateOrderBy>;
-  title?: InputMaybe<OrderBy>;
-  updated_at?: InputMaybe<OrderBy>;
-};
-
-/** select columns of table "seos" */
-export enum SeosSelectColumn {
-  /** column name */
-  CREATED_AT = "created_at",
-  /** column name */
-  DELETED_AT = "deleted_at",
-  /** column name */
-  DESCRIPTION = "description",
-  /** column name */
-  ID = "id",
-  /** column name */
-  OG_IMAGE_URL = "og_image_url",
-  /** column name */
-  TITLE = "title",
-  /** column name */
-  UPDATED_AT = "updated_at",
-}
-
-/** Streaming cursor of the table "seos" */
-export type SeosStreamCursorInput = {
-  /** Stream column input with initial value */
-  initial_value: SeosStreamCursorValueInput;
-  /** cursor ordering */
-  ordering?: InputMaybe<CursorOrdering>;
-};
-
-/** Initial value of the column from where the streaming should start */
-export type SeosStreamCursorValueInput = {
-  /** 作成日時 */
-  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** 削除日時 */
-  deleted_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-  /** 説明文 */
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  /** SEO ID */
-  id?: InputMaybe<Scalars["uuid"]["input"]>;
-  /** カスタム OG 画像 URL ( 1280✕720 ) */
-  og_image_url?: InputMaybe<Scalars["String"]["input"]>;
-  /** タイトル */
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  /** 更新日時 */
-  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
-};
-
-/** Boolean expression to compare columns of type "smallint". All fields are combined with logical 'AND'. */
-export type SmallintComparisonExp = {
-  _eq?: InputMaybe<Scalars["smallint"]["input"]>;
-  _gt?: InputMaybe<Scalars["smallint"]["input"]>;
-  _gte?: InputMaybe<Scalars["smallint"]["input"]>;
-  _in?: InputMaybe<Array<Scalars["smallint"]["input"]>>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
-  _lt?: InputMaybe<Scalars["smallint"]["input"]>;
-  _lte?: InputMaybe<Scalars["smallint"]["input"]>;
-  _neq?: InputMaybe<Scalars["smallint"]["input"]>;
-  _nin?: InputMaybe<Array<Scalars["smallint"]["input"]>>;
-};
-
-export type SubscriptionRoot = {
-  __typename?: "subscription_root";
-  /** fetch data from the table: "assets" */
-  assets: Array<Assets>;
-  /** fetch data from the table: "assets" using primary key columns */
-  assets_by_pk?: Maybe<Assets>;
-  /** fetch data from the table in a streaming manner: "assets" */
-  assets_stream: Array<Assets>;
-  /** An array relationship */
-  post_tags: Array<PostTags>;
-  /** fetch data from the table: "post_tags" using primary key columns */
-  post_tags_by_pk?: Maybe<PostTags>;
-  /** fetch data from the table in a streaming manner: "post_tags" */
-  post_tags_stream: Array<PostTags>;
-  /** An array relationship */
-  posts: Array<Posts>;
-  /** fetch data from the table: "posts" using primary key columns */
-  posts_by_pk?: Maybe<Posts>;
-  /** fetch data from the table in a streaming manner: "posts" */
-  posts_stream: Array<Posts>;
-  /** fetch data from the table: "seos" */
-  seos: Array<Seos>;
-  /** fetch data from the table: "seos" using primary key columns */
-  seos_by_pk?: Maybe<Seos>;
-  /** fetch data from the table in a streaming manner: "seos" */
-  seos_stream: Array<Seos>;
-  /** fetch data from the table: "tags" */
-  tags: Array<Tags>;
-  /** fetch data from the table: "tags" using primary key columns */
-  tags_by_pk?: Maybe<Tags>;
-  /** fetch data from the table in a streaming manner: "tags" */
-  tags_stream: Array<Tags>;
-};
-
-export type SubscriptionRootAssetsArgs = {
-  distinct_on?: InputMaybe<Array<AssetsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<AssetsOrderBy>>;
-  where?: InputMaybe<AssetsBoolExp>;
-};
-
-export type SubscriptionRootAssetsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type SubscriptionRootAssetsStreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<AssetsStreamCursorInput>>;
-  where?: InputMaybe<AssetsBoolExp>;
-};
-
-export type SubscriptionRootPostTagsArgs = {
-  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
-  where?: InputMaybe<PostTagsBoolExp>;
-};
-
-export type SubscriptionRootPostTagsByPkArgs = {
-  post_id: Scalars["uuid"]["input"];
-  tag_id: Scalars["uuid"]["input"];
-};
-
-export type SubscriptionRootPostTagsStreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<PostTagsStreamCursorInput>>;
-  where?: InputMaybe<PostTagsBoolExp>;
-};
-
-export type SubscriptionRootPostsArgs = {
-  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostsOrderBy>>;
-  where?: InputMaybe<PostsBoolExp>;
-};
-
-export type SubscriptionRootPostsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type SubscriptionRootPostsStreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<PostsStreamCursorInput>>;
-  where?: InputMaybe<PostsBoolExp>;
-};
-
-export type SubscriptionRootSeosArgs = {
-  distinct_on?: InputMaybe<Array<SeosSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<SeosOrderBy>>;
-  where?: InputMaybe<SeosBoolExp>;
-};
-
-export type SubscriptionRootSeosByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type SubscriptionRootSeosStreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<SeosStreamCursorInput>>;
-  where?: InputMaybe<SeosBoolExp>;
-};
-
-export type SubscriptionRootTagsArgs = {
-  distinct_on?: InputMaybe<Array<TagsSelectColumn>>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<TagsOrderBy>>;
-  where?: InputMaybe<TagsBoolExp>;
-};
-
-export type SubscriptionRootTagsByPkArgs = {
-  id: Scalars["uuid"]["input"];
-};
-
-export type SubscriptionRootTagsStreamArgs = {
-  batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<TagsStreamCursorInput>>;
-  where?: InputMaybe<TagsBoolExp>;
-};
-
 /** タグ */
 export type Tags = {
-  __typename?: "tags";
+  __typename?: "Tags";
   /** 作成日時 */
-  created_at: Scalars["timestamptz"]["output"];
+  createdAt: Scalars["timestamptz"]["output"];
   /** 説明文 */
   description: Scalars["String"]["output"];
   /** タグID */
@@ -824,15 +614,15 @@ export type Tags = {
   /** タグ */
   tag: Scalars["String"]["output"];
   /** 更新日時 */
-  updated_at: Scalars["timestamptz"]["output"];
+  updatedAt: Scalars["timestamptz"]["output"];
 };
 
 /** タグ */
 export type TagsPostTagsArgs = {
-  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
+  distinctOn?: InputMaybe<Array<PostTagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
+  orderBy?: InputMaybe<Array<PostTagsOrderBy>>;
   where?: InputMaybe<PostTagsBoolExp>;
 };
 
@@ -841,28 +631,28 @@ export type TagsBoolExp = {
   _and?: InputMaybe<Array<TagsBoolExp>>;
   _not?: InputMaybe<TagsBoolExp>;
   _or?: InputMaybe<Array<TagsBoolExp>>;
-  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
   description?: InputMaybe<StringComparisonExp>;
   id?: InputMaybe<UuidComparisonExp>;
   post_tags?: InputMaybe<PostTagsBoolExp>;
   tag?: InputMaybe<StringComparisonExp>;
-  updated_at?: InputMaybe<TimestamptzComparisonExp>;
+  updatedAt?: InputMaybe<TimestamptzComparisonExp>;
 };
 
 /** Ordering options when selecting data from "tags". */
 export type TagsOrderBy = {
-  created_at?: InputMaybe<OrderBy>;
+  createdAt?: InputMaybe<OrderBy>;
   description?: InputMaybe<OrderBy>;
   id?: InputMaybe<OrderBy>;
-  post_tags_aggregate?: InputMaybe<PostTagsAggregateOrderBy>;
+  post_tagsAggregate?: InputMaybe<PostTagsAggregateOrderBy>;
   tag?: InputMaybe<OrderBy>;
-  updated_at?: InputMaybe<OrderBy>;
+  updatedAt?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "tags" */
 export enum TagsSelectColumn {
   /** column name */
-  CREATED_AT = "created_at",
+  CREATEDAT = "createdAt",
   /** column name */
   DESCRIPTION = "description",
   /** column name */
@@ -870,13 +660,13 @@ export enum TagsSelectColumn {
   /** column name */
   TAG = "tag",
   /** column name */
-  UPDATED_AT = "updated_at",
+  UPDATEDAT = "updatedAt",
 }
 
 /** Streaming cursor of the table "tags" */
 export type TagsStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: TagsStreamCursorValueInput;
+  initialValue: TagsStreamCursorValueInput;
   /** cursor ordering */
   ordering?: InputMaybe<CursorOrdering>;
 };
@@ -884,7 +674,7 @@ export type TagsStreamCursorInput = {
 /** Initial value of the column from where the streaming should start */
 export type TagsStreamCursorValueInput = {
   /** 作成日時 */
-  created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** 説明文 */
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** タグID */
@@ -892,7 +682,7 @@ export type TagsStreamCursorValueInput = {
   /** タグ */
   tag?: InputMaybe<Scalars["String"]["input"]>;
   /** 更新日時 */
-  updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  updatedAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
 };
 
 /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
@@ -901,7 +691,7 @@ export type TimestamptzComparisonExp = {
   _gt?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _gte?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _in?: InputMaybe<Array<Scalars["timestamptz"]["input"]>>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
   _lt?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _lte?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _neq?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -914,11 +704,221 @@ export type UuidComparisonExp = {
   _gt?: InputMaybe<Scalars["uuid"]["input"]>;
   _gte?: InputMaybe<Scalars["uuid"]["input"]>;
   _in?: InputMaybe<Array<Scalars["uuid"]["input"]>>;
-  _is_null?: InputMaybe<Scalars["Boolean"]["input"]>;
+  _isNull?: InputMaybe<Scalars["Boolean"]["input"]>;
   _lt?: InputMaybe<Scalars["uuid"]["input"]>;
   _lte?: InputMaybe<Scalars["uuid"]["input"]>;
   _neq?: InputMaybe<Scalars["uuid"]["input"]>;
   _nin?: InputMaybe<Array<Scalars["uuid"]["input"]>>;
+};
+
+export type QueryRoot = {
+  __typename?: "query_root";
+  /** fetch data from the table: "assets" */
+  assets: Array<Assets>;
+  /** fetch data from the table: "assets" using primary key columns */
+  assetsByPk?: Maybe<Assets>;
+  /** fetch data from the table: "post_tags" */
+  postTags: Array<PostTags>;
+  /** fetch data from the table: "post_tags" using primary key columns */
+  postTagsByPk?: Maybe<PostTags>;
+  /** An array relationship */
+  posts: Array<Posts>;
+  /** fetch data from the table: "posts" using primary key columns */
+  postsByPk?: Maybe<Posts>;
+  /** fetch data from the table: "seos" */
+  seos: Array<Seos>;
+  /** fetch data from the table: "seos" using primary key columns */
+  seosByPk?: Maybe<Seos>;
+  /** fetch data from the table: "tags" */
+  tags: Array<Tags>;
+  /** fetch data from the table: "tags" using primary key columns */
+  tagsByPk?: Maybe<Tags>;
+};
+
+export type QueryRootAssetsArgs = {
+  distinctOn?: InputMaybe<Array<AssetsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<AssetsOrderBy>>;
+  where?: InputMaybe<AssetsBoolExp>;
+};
+
+export type QueryRootAssetsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type QueryRootPostTagsArgs = {
+  distinctOn?: InputMaybe<Array<PostTagsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
+};
+
+export type QueryRootPostTagsByPkArgs = {
+  postId: Scalars["uuid"]["input"];
+  tagId: Scalars["uuid"]["input"];
+};
+
+export type QueryRootPostsArgs = {
+  distinctOn?: InputMaybe<Array<PostsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
+};
+
+export type QueryRootPostsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type QueryRootSeosArgs = {
+  distinctOn?: InputMaybe<Array<SeosSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<SeosOrderBy>>;
+  where?: InputMaybe<SeosBoolExp>;
+};
+
+export type QueryRootSeosByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type QueryRootTagsArgs = {
+  distinctOn?: InputMaybe<Array<TagsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<TagsOrderBy>>;
+  where?: InputMaybe<TagsBoolExp>;
+};
+
+export type QueryRootTagsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRoot = {
+  __typename?: "subscription_root";
+  /** fetch data from the table: "assets" */
+  assets: Array<Assets>;
+  /** fetch data from the table: "assets" using primary key columns */
+  assetsByPk?: Maybe<Assets>;
+  /** fetch data from the table in a streaming manner: "assets" */
+  assetsStream: Array<Assets>;
+  /** fetch data from the table: "post_tags" */
+  postTags: Array<PostTags>;
+  /** fetch data from the table: "post_tags" using primary key columns */
+  postTagsByPk?: Maybe<PostTags>;
+  /** fetch data from the table in a streaming manner: "post_tags" */
+  postTagsStream: Array<PostTags>;
+  /** An array relationship */
+  posts: Array<Posts>;
+  /** fetch data from the table: "posts" using primary key columns */
+  postsByPk?: Maybe<Posts>;
+  /** fetch data from the table in a streaming manner: "posts" */
+  postsStream: Array<Posts>;
+  /** fetch data from the table: "seos" */
+  seos: Array<Seos>;
+  /** fetch data from the table: "seos" using primary key columns */
+  seosByPk?: Maybe<Seos>;
+  /** fetch data from the table in a streaming manner: "seos" */
+  seosStream: Array<Seos>;
+  /** fetch data from the table: "tags" */
+  tags: Array<Tags>;
+  /** fetch data from the table: "tags" using primary key columns */
+  tagsByPk?: Maybe<Tags>;
+  /** fetch data from the table in a streaming manner: "tags" */
+  tagsStream: Array<Tags>;
+};
+
+export type SubscriptionRootAssetsArgs = {
+  distinctOn?: InputMaybe<Array<AssetsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<AssetsOrderBy>>;
+  where?: InputMaybe<AssetsBoolExp>;
+};
+
+export type SubscriptionRootAssetsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRootAssetsStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<AssetsStreamCursorInput>>;
+  where?: InputMaybe<AssetsBoolExp>;
+};
+
+export type SubscriptionRootPostTagsArgs = {
+  distinctOn?: InputMaybe<Array<PostTagsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
+};
+
+export type SubscriptionRootPostTagsByPkArgs = {
+  postId: Scalars["uuid"]["input"];
+  tagId: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRootPostTagsStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<PostTagsStreamCursorInput>>;
+  where?: InputMaybe<PostTagsBoolExp>;
+};
+
+export type SubscriptionRootPostsArgs = {
+  distinctOn?: InputMaybe<Array<PostsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
+};
+
+export type SubscriptionRootPostsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRootPostsStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<PostsStreamCursorInput>>;
+  where?: InputMaybe<PostsBoolExp>;
+};
+
+export type SubscriptionRootSeosArgs = {
+  distinctOn?: InputMaybe<Array<SeosSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<SeosOrderBy>>;
+  where?: InputMaybe<SeosBoolExp>;
+};
+
+export type SubscriptionRootSeosByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRootSeosStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<SeosStreamCursorInput>>;
+  where?: InputMaybe<SeosBoolExp>;
+};
+
+export type SubscriptionRootTagsArgs = {
+  distinctOn?: InputMaybe<Array<TagsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<TagsOrderBy>>;
+  where?: InputMaybe<TagsBoolExp>;
+};
+
+export type SubscriptionRootTagsByPkArgs = {
+  id: Scalars["uuid"]["input"];
+};
+
+export type SubscriptionRootTagsStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<TagsStreamCursorInput>>;
+  where?: InputMaybe<TagsBoolExp>;
 };
 
 export type PostsQueryVariables = Exact<{
@@ -928,12 +928,12 @@ export type PostsQueryVariables = Exact<{
 export type PostsQuery = {
   __typename?: "query_root";
   posts: Array<{
-    __typename?: "posts";
+    __typename?: "Posts";
     id: string;
     title: string;
     excerpt: string;
-    published_at?: Date | null;
-    coverImage?: { __typename?: "assets"; url: string } | null;
+    publishedAt?: Date | null;
+    coverImage?: { __typename?: "Assets"; url: string } | null;
   }>;
 };
 
@@ -941,7 +941,7 @@ export type PostIdsQueryVariables = Exact<{
   now: Scalars["timestamptz"]["input"];
 }>;
 
-export type PostIdsQuery = { __typename?: "query_root"; posts: Array<{ __typename?: "posts"; id: string }> };
+export type PostIdsQuery = { __typename?: "query_root"; posts: Array<{ __typename?: "Posts"; id: string }> };
 
 export type PostMetadataQueryVariables = Exact<{
   id: Scalars["uuid"]["input"];
@@ -949,7 +949,7 @@ export type PostMetadataQueryVariables = Exact<{
 
 export type PostMetadataQuery = {
   __typename?: "query_root";
-  posts_by_pk?: { __typename?: "posts"; title: string; excerpt: string } | null;
+  postsByPk?: { __typename?: "Posts"; title: string; excerpt: string } | null;
 };
 
 export type PostQueryVariables = Exact<{
@@ -958,14 +958,14 @@ export type PostQueryVariables = Exact<{
 
 export type PostQuery = {
   __typename?: "query_root";
-  posts_by_pk?: {
-    __typename?: "posts";
+  postsByPk?: {
+    __typename?: "Posts";
     title: string;
     excerpt: string;
-    published_at?: Date | null;
+    publishedAt?: Date | null;
     content: string;
-    coverImage?: { __typename?: "assets"; url: string } | null;
-    post_tags: Array<{ __typename?: "post_tags"; tag: { __typename?: "tags"; tag: string } }>;
+    coverImage?: { __typename?: "Assets"; url: string } | null;
+    post_tags: Array<{ __typename?: "PostTags"; tag: { __typename?: "Tags"; tag: string } }>;
   } | null;
 };
 
@@ -992,14 +992,14 @@ export const PostsDocument = {
             arguments: [
               {
                 kind: "Argument",
-                name: { kind: "Name", value: "order_by" },
+                name: { kind: "Name", value: "orderBy" },
                 value: {
                   kind: "ObjectValue",
                   fields: [
                     {
                       kind: "ObjectField",
-                      name: { kind: "Name", value: "published_at" },
-                      value: { kind: "EnumValue", value: "desc" },
+                      name: { kind: "Name", value: "publishedAt" },
+                      value: { kind: "EnumValue", value: "DESC" },
                     },
                   ],
                 },
@@ -1012,7 +1012,7 @@ export const PostsDocument = {
                   fields: [
                     {
                       kind: "ObjectField",
-                      name: { kind: "Name", value: "published_at" },
+                      name: { kind: "Name", value: "publishedAt" },
                       value: {
                         kind: "ObjectValue",
                         fields: [
@@ -1034,7 +1034,7 @@ export const PostsDocument = {
                 { kind: "Field", name: { kind: "Name", value: "id" } },
                 { kind: "Field", name: { kind: "Name", value: "title" } },
                 { kind: "Field", name: { kind: "Name", value: "excerpt" } },
-                { kind: "Field", name: { kind: "Name", value: "published_at" } },
+                { kind: "Field", name: { kind: "Name", value: "publishedAt" } },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "coverImage" },
@@ -1080,7 +1080,7 @@ export const PostIdsDocument = {
                   fields: [
                     {
                       kind: "ObjectField",
-                      name: { kind: "Name", value: "published_at" },
+                      name: { kind: "Name", value: "publishedAt" },
                       value: {
                         kind: "ObjectValue",
                         fields: [
@@ -1125,7 +1125,7 @@ export const PostMetadataDocument = {
         selections: [
           {
             kind: "Field",
-            name: { kind: "Name", value: "posts_by_pk" },
+            name: { kind: "Name", value: "postsByPk" },
             arguments: [
               {
                 kind: "Argument",
@@ -1165,7 +1165,7 @@ export const PostDocument = {
         selections: [
           {
             kind: "Field",
-            name: { kind: "Name", value: "posts_by_pk" },
+            name: { kind: "Name", value: "postsByPk" },
             arguments: [
               {
                 kind: "Argument",
@@ -1178,7 +1178,7 @@ export const PostDocument = {
               selections: [
                 { kind: "Field", name: { kind: "Name", value: "title" } },
                 { kind: "Field", name: { kind: "Name", value: "excerpt" } },
-                { kind: "Field", name: { kind: "Name", value: "published_at" } },
+                { kind: "Field", name: { kind: "Name", value: "publishedAt" } },
                 {
                   kind: "Field",
                   name: { kind: "Name", value: "coverImage" },

--- a/apps/frontend/src/gql/graphql.ts
+++ b/apps/frontend/src/gql/graphql.ts
@@ -16,12 +16,12 @@ export type Scalars = {
   Int: { input: number; output: number };
   Float: { input: number; output: number };
   smallint: { input: any; output: any };
-  timestamptz: { input: any; output: any };
-  uuid: { input: any; output: any };
+  timestamptz: { input: Date; output: Date };
+  uuid: { input: string; output: string };
 };
 
 /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
-export type Int_Comparison_Exp = {
+export type IntComparisonExp = {
   _eq?: InputMaybe<Scalars["Int"]["input"]>;
   _gt?: InputMaybe<Scalars["Int"]["input"]>;
   _gte?: InputMaybe<Scalars["Int"]["input"]>;
@@ -34,7 +34,7 @@ export type Int_Comparison_Exp = {
 };
 
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
-export type String_Comparison_Exp = {
+export type StringComparisonExp = {
   _eq?: InputMaybe<Scalars["String"]["input"]>;
   _gt?: InputMaybe<Scalars["String"]["input"]>;
   _gte?: InputMaybe<Scalars["String"]["input"]>;
@@ -93,76 +93,76 @@ export type Assets = {
 
 /** アセット */
 export type AssetsPostsArgs = {
-  distinct_on?: InputMaybe<Array<Posts_Select_Column>>;
+  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Posts_Order_By>>;
-  where?: InputMaybe<Posts_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
 };
 
 /** Boolean expression to filter rows from the table "assets". All fields are combined with a logical 'AND'. */
-export type Assets_Bool_Exp = {
-  _and?: InputMaybe<Array<Assets_Bool_Exp>>;
-  _not?: InputMaybe<Assets_Bool_Exp>;
-  _or?: InputMaybe<Array<Assets_Bool_Exp>>;
-  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  file_name?: InputMaybe<String_Comparison_Exp>;
-  height?: InputMaybe<Smallint_Comparison_Exp>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  mime_type?: InputMaybe<String_Comparison_Exp>;
-  posts?: InputMaybe<Posts_Bool_Exp>;
-  size?: InputMaybe<Int_Comparison_Exp>;
-  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  url?: InputMaybe<String_Comparison_Exp>;
-  width?: InputMaybe<Smallint_Comparison_Exp>;
+export type AssetsBoolExp = {
+  _and?: InputMaybe<Array<AssetsBoolExp>>;
+  _not?: InputMaybe<AssetsBoolExp>;
+  _or?: InputMaybe<Array<AssetsBoolExp>>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  file_name?: InputMaybe<StringComparisonExp>;
+  height?: InputMaybe<SmallintComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  mime_type?: InputMaybe<StringComparisonExp>;
+  posts?: InputMaybe<PostsBoolExp>;
+  size?: InputMaybe<IntComparisonExp>;
+  updated_at?: InputMaybe<TimestamptzComparisonExp>;
+  url?: InputMaybe<StringComparisonExp>;
+  width?: InputMaybe<SmallintComparisonExp>;
 };
 
 /** Ordering options when selecting data from "assets". */
-export type Assets_Order_By = {
-  created_at?: InputMaybe<Order_By>;
-  file_name?: InputMaybe<Order_By>;
-  height?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  mime_type?: InputMaybe<Order_By>;
-  posts_aggregate?: InputMaybe<Posts_Aggregate_Order_By>;
-  size?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
-  url?: InputMaybe<Order_By>;
-  width?: InputMaybe<Order_By>;
+export type AssetsOrderBy = {
+  created_at?: InputMaybe<OrderBy>;
+  file_name?: InputMaybe<OrderBy>;
+  height?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  mime_type?: InputMaybe<OrderBy>;
+  posts_aggregate?: InputMaybe<PostsAggregateOrderBy>;
+  size?: InputMaybe<OrderBy>;
+  updated_at?: InputMaybe<OrderBy>;
+  url?: InputMaybe<OrderBy>;
+  width?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "assets" */
-export enum Assets_Select_Column {
+export enum AssetsSelectColumn {
   /** column name */
-  CreatedAt = "created_at",
+  CREATED_AT = "created_at",
   /** column name */
-  FileName = "file_name",
+  FILE_NAME = "file_name",
   /** column name */
-  Height = "height",
+  HEIGHT = "height",
   /** column name */
-  Id = "id",
+  ID = "id",
   /** column name */
-  MimeType = "mime_type",
+  MIME_TYPE = "mime_type",
   /** column name */
-  Size = "size",
+  SIZE = "size",
   /** column name */
-  UpdatedAt = "updated_at",
+  UPDATED_AT = "updated_at",
   /** column name */
-  Url = "url",
+  URL = "url",
   /** column name */
-  Width = "width",
+  WIDTH = "width",
 }
 
 /** Streaming cursor of the table "assets" */
-export type Assets_Stream_Cursor_Input = {
+export type AssetsStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: Assets_Stream_Cursor_Value_Input;
+  initial_value: AssetsStreamCursorValueInput;
   /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
+  ordering?: InputMaybe<CursorOrdering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Assets_Stream_Cursor_Value_Input = {
+export type AssetsStreamCursorValueInput = {
   /** 作成日時 */
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** 説明文 */
@@ -184,31 +184,31 @@ export type Assets_Stream_Cursor_Value_Input = {
 };
 
 /** ordering argument of a cursor */
-export enum Cursor_Ordering {
+export enum CursorOrdering {
   /** ascending ordering of the cursor */
-  Asc = "ASC",
+  ASC = "ASC",
   /** descending ordering of the cursor */
-  Desc = "DESC",
+  DESC = "DESC",
 }
 
 /** column ordering options */
-export enum Order_By {
+export enum OrderBy {
   /** in ascending order, nulls last */
-  Asc = "asc",
+  ASC = "asc",
   /** in ascending order, nulls first */
-  AscNullsFirst = "asc_nulls_first",
+  ASC_NULLS_FIRST = "asc_nulls_first",
   /** in ascending order, nulls last */
-  AscNullsLast = "asc_nulls_last",
+  ASC_NULLS_LAST = "asc_nulls_last",
   /** in descending order, nulls first */
-  Desc = "desc",
+  DESC = "desc",
   /** in descending order, nulls first */
-  DescNullsFirst = "desc_nulls_first",
+  DESC_NULLS_FIRST = "desc_nulls_first",
   /** in descending order, nulls last */
-  DescNullsLast = "desc_nulls_last",
+  DESC_NULLS_LAST = "desc_nulls_last",
 }
 
 /** ポストとタグの関連付け */
-export type Post_Tags = {
+export type PostTags = {
   __typename?: "post_tags";
   /** An object relationship */
   post: Posts;
@@ -221,65 +221,65 @@ export type Post_Tags = {
 };
 
 /** order by aggregate values of table "post_tags" */
-export type Post_Tags_Aggregate_Order_By = {
-  count?: InputMaybe<Order_By>;
-  max?: InputMaybe<Post_Tags_Max_Order_By>;
-  min?: InputMaybe<Post_Tags_Min_Order_By>;
+export type PostTagsAggregateOrderBy = {
+  count?: InputMaybe<OrderBy>;
+  max?: InputMaybe<PostTagsMaxOrderBy>;
+  min?: InputMaybe<PostTagsMinOrderBy>;
 };
 
 /** Boolean expression to filter rows from the table "post_tags". All fields are combined with a logical 'AND'. */
-export type Post_Tags_Bool_Exp = {
-  _and?: InputMaybe<Array<Post_Tags_Bool_Exp>>;
-  _not?: InputMaybe<Post_Tags_Bool_Exp>;
-  _or?: InputMaybe<Array<Post_Tags_Bool_Exp>>;
-  post?: InputMaybe<Posts_Bool_Exp>;
-  post_id?: InputMaybe<Uuid_Comparison_Exp>;
-  tag?: InputMaybe<Tags_Bool_Exp>;
-  tag_id?: InputMaybe<Uuid_Comparison_Exp>;
+export type PostTagsBoolExp = {
+  _and?: InputMaybe<Array<PostTagsBoolExp>>;
+  _not?: InputMaybe<PostTagsBoolExp>;
+  _or?: InputMaybe<Array<PostTagsBoolExp>>;
+  post?: InputMaybe<PostsBoolExp>;
+  post_id?: InputMaybe<UuidComparisonExp>;
+  tag?: InputMaybe<TagsBoolExp>;
+  tag_id?: InputMaybe<UuidComparisonExp>;
 };
 
 /** order by max() on columns of table "post_tags" */
-export type Post_Tags_Max_Order_By = {
+export type PostTagsMaxOrderBy = {
   /** ポストID */
-  post_id?: InputMaybe<Order_By>;
+  post_id?: InputMaybe<OrderBy>;
   /** タグID */
-  tag_id?: InputMaybe<Order_By>;
+  tag_id?: InputMaybe<OrderBy>;
 };
 
 /** order by min() on columns of table "post_tags" */
-export type Post_Tags_Min_Order_By = {
+export type PostTagsMinOrderBy = {
   /** ポストID */
-  post_id?: InputMaybe<Order_By>;
+  post_id?: InputMaybe<OrderBy>;
   /** タグID */
-  tag_id?: InputMaybe<Order_By>;
+  tag_id?: InputMaybe<OrderBy>;
 };
 
 /** Ordering options when selecting data from "post_tags". */
-export type Post_Tags_Order_By = {
-  post?: InputMaybe<Posts_Order_By>;
-  post_id?: InputMaybe<Order_By>;
-  tag?: InputMaybe<Tags_Order_By>;
-  tag_id?: InputMaybe<Order_By>;
+export type PostTagsOrderBy = {
+  post?: InputMaybe<PostsOrderBy>;
+  post_id?: InputMaybe<OrderBy>;
+  tag?: InputMaybe<TagsOrderBy>;
+  tag_id?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "post_tags" */
-export enum Post_Tags_Select_Column {
+export enum PostTagsSelectColumn {
   /** column name */
-  PostId = "post_id",
+  POST_ID = "post_id",
   /** column name */
-  TagId = "tag_id",
+  TAG_ID = "tag_id",
 }
 
 /** Streaming cursor of the table "post_tags" */
-export type Post_Tags_Stream_Cursor_Input = {
+export type PostTagsStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: Post_Tags_Stream_Cursor_Value_Input;
+  initial_value: PostTagsStreamCursorValueInput;
   /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
+  ordering?: InputMaybe<CursorOrdering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Post_Tags_Stream_Cursor_Value_Input = {
+export type PostTagsStreamCursorValueInput = {
   /** ポストID */
   post_id?: InputMaybe<Scalars["uuid"]["input"]>;
   /** タグID */
@@ -304,7 +304,7 @@ export type Posts = {
   /** ポスト ID */
   id: Scalars["uuid"]["output"];
   /** An array relationship */
-  post_tags: Array<Post_Tags>;
+  post_tags: Array<PostTags>;
   /** 公開日時 */
   published_at?: Maybe<Scalars["timestamptz"]["output"]>;
   /** An object relationship */
@@ -320,148 +320,148 @@ export type Posts = {
 };
 
 /** ポスト */
-export type PostsPost_TagsArgs = {
-  distinct_on?: InputMaybe<Array<Post_Tags_Select_Column>>;
+export type PostsPostTagsArgs = {
+  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Post_Tags_Order_By>>;
-  where?: InputMaybe<Post_Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
 };
 
 /** order by aggregate values of table "posts" */
-export type Posts_Aggregate_Order_By = {
-  count?: InputMaybe<Order_By>;
-  max?: InputMaybe<Posts_Max_Order_By>;
-  min?: InputMaybe<Posts_Min_Order_By>;
+export type PostsAggregateOrderBy = {
+  count?: InputMaybe<OrderBy>;
+  max?: InputMaybe<PostsMaxOrderBy>;
+  min?: InputMaybe<PostsMinOrderBy>;
 };
 
 /** Boolean expression to filter rows from the table "posts". All fields are combined with a logical 'AND'. */
-export type Posts_Bool_Exp = {
-  _and?: InputMaybe<Array<Posts_Bool_Exp>>;
-  _not?: InputMaybe<Posts_Bool_Exp>;
-  _or?: InputMaybe<Array<Posts_Bool_Exp>>;
-  content?: InputMaybe<String_Comparison_Exp>;
-  coverImage?: InputMaybe<Assets_Bool_Exp>;
-  cover_image_id?: InputMaybe<Uuid_Comparison_Exp>;
-  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  deleted_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  excerpt?: InputMaybe<String_Comparison_Exp>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  post_tags?: InputMaybe<Post_Tags_Bool_Exp>;
-  published_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  seo?: InputMaybe<Seos_Bool_Exp>;
-  seo_id?: InputMaybe<Uuid_Comparison_Exp>;
-  slug?: InputMaybe<String_Comparison_Exp>;
-  title?: InputMaybe<String_Comparison_Exp>;
-  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+export type PostsBoolExp = {
+  _and?: InputMaybe<Array<PostsBoolExp>>;
+  _not?: InputMaybe<PostsBoolExp>;
+  _or?: InputMaybe<Array<PostsBoolExp>>;
+  content?: InputMaybe<StringComparisonExp>;
+  coverImage?: InputMaybe<AssetsBoolExp>;
+  cover_image_id?: InputMaybe<UuidComparisonExp>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  deleted_at?: InputMaybe<TimestamptzComparisonExp>;
+  excerpt?: InputMaybe<StringComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  post_tags?: InputMaybe<PostTagsBoolExp>;
+  published_at?: InputMaybe<TimestamptzComparisonExp>;
+  seo?: InputMaybe<SeosBoolExp>;
+  seo_id?: InputMaybe<UuidComparisonExp>;
+  slug?: InputMaybe<StringComparisonExp>;
+  title?: InputMaybe<StringComparisonExp>;
+  updated_at?: InputMaybe<TimestamptzComparisonExp>;
 };
 
 /** order by max() on columns of table "posts" */
-export type Posts_Max_Order_By = {
+export type PostsMaxOrderBy = {
   /** 内容 */
-  content?: InputMaybe<Order_By>;
+  content?: InputMaybe<OrderBy>;
   /** カバー画像 */
-  cover_image_id?: InputMaybe<Order_By>;
+  cover_image_id?: InputMaybe<OrderBy>;
   /** 作成日時 */
-  created_at?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<OrderBy>;
   /** 削除日時 */
-  deleted_at?: InputMaybe<Order_By>;
+  deleted_at?: InputMaybe<OrderBy>;
   /** 抜粋 */
-  excerpt?: InputMaybe<Order_By>;
+  excerpt?: InputMaybe<OrderBy>;
   /** ポスト ID */
-  id?: InputMaybe<Order_By>;
+  id?: InputMaybe<OrderBy>;
   /** 公開日時 */
-  published_at?: InputMaybe<Order_By>;
+  published_at?: InputMaybe<OrderBy>;
   /** SEO */
-  seo_id?: InputMaybe<Order_By>;
+  seo_id?: InputMaybe<OrderBy>;
   /** ラベル文字列 */
-  slug?: InputMaybe<Order_By>;
+  slug?: InputMaybe<OrderBy>;
   /** タイトル */
-  title?: InputMaybe<Order_By>;
+  title?: InputMaybe<OrderBy>;
   /** 更新日時 */
-  updated_at?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<OrderBy>;
 };
 
 /** order by min() on columns of table "posts" */
-export type Posts_Min_Order_By = {
+export type PostsMinOrderBy = {
   /** 内容 */
-  content?: InputMaybe<Order_By>;
+  content?: InputMaybe<OrderBy>;
   /** カバー画像 */
-  cover_image_id?: InputMaybe<Order_By>;
+  cover_image_id?: InputMaybe<OrderBy>;
   /** 作成日時 */
-  created_at?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<OrderBy>;
   /** 削除日時 */
-  deleted_at?: InputMaybe<Order_By>;
+  deleted_at?: InputMaybe<OrderBy>;
   /** 抜粋 */
-  excerpt?: InputMaybe<Order_By>;
+  excerpt?: InputMaybe<OrderBy>;
   /** ポスト ID */
-  id?: InputMaybe<Order_By>;
+  id?: InputMaybe<OrderBy>;
   /** 公開日時 */
-  published_at?: InputMaybe<Order_By>;
+  published_at?: InputMaybe<OrderBy>;
   /** SEO */
-  seo_id?: InputMaybe<Order_By>;
+  seo_id?: InputMaybe<OrderBy>;
   /** ラベル文字列 */
-  slug?: InputMaybe<Order_By>;
+  slug?: InputMaybe<OrderBy>;
   /** タイトル */
-  title?: InputMaybe<Order_By>;
+  title?: InputMaybe<OrderBy>;
   /** 更新日時 */
-  updated_at?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<OrderBy>;
 };
 
 /** Ordering options when selecting data from "posts". */
-export type Posts_Order_By = {
-  content?: InputMaybe<Order_By>;
-  coverImage?: InputMaybe<Assets_Order_By>;
-  cover_image_id?: InputMaybe<Order_By>;
-  created_at?: InputMaybe<Order_By>;
-  deleted_at?: InputMaybe<Order_By>;
-  excerpt?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  post_tags_aggregate?: InputMaybe<Post_Tags_Aggregate_Order_By>;
-  published_at?: InputMaybe<Order_By>;
-  seo?: InputMaybe<Seos_Order_By>;
-  seo_id?: InputMaybe<Order_By>;
-  slug?: InputMaybe<Order_By>;
-  title?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
+export type PostsOrderBy = {
+  content?: InputMaybe<OrderBy>;
+  coverImage?: InputMaybe<AssetsOrderBy>;
+  cover_image_id?: InputMaybe<OrderBy>;
+  created_at?: InputMaybe<OrderBy>;
+  deleted_at?: InputMaybe<OrderBy>;
+  excerpt?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  post_tags_aggregate?: InputMaybe<PostTagsAggregateOrderBy>;
+  published_at?: InputMaybe<OrderBy>;
+  seo?: InputMaybe<SeosOrderBy>;
+  seo_id?: InputMaybe<OrderBy>;
+  slug?: InputMaybe<OrderBy>;
+  title?: InputMaybe<OrderBy>;
+  updated_at?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "posts" */
-export enum Posts_Select_Column {
+export enum PostsSelectColumn {
   /** column name */
-  Content = "content",
+  CONTENT = "content",
   /** column name */
-  CoverImageId = "cover_image_id",
+  COVER_IMAGE_ID = "cover_image_id",
   /** column name */
-  CreatedAt = "created_at",
+  CREATED_AT = "created_at",
   /** column name */
-  DeletedAt = "deleted_at",
+  DELETED_AT = "deleted_at",
   /** column name */
-  Excerpt = "excerpt",
+  EXCERPT = "excerpt",
   /** column name */
-  Id = "id",
+  ID = "id",
   /** column name */
-  PublishedAt = "published_at",
+  PUBLISHED_AT = "published_at",
   /** column name */
-  SeoId = "seo_id",
+  SEO_ID = "seo_id",
   /** column name */
-  Slug = "slug",
+  SLUG = "slug",
   /** column name */
-  Title = "title",
+  TITLE = "title",
   /** column name */
-  UpdatedAt = "updated_at",
+  UPDATED_AT = "updated_at",
 }
 
 /** Streaming cursor of the table "posts" */
-export type Posts_Stream_Cursor_Input = {
+export type PostsStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: Posts_Stream_Cursor_Value_Input;
+  initial_value: PostsStreamCursorValueInput;
   /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
+  ordering?: InputMaybe<CursorOrdering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Posts_Stream_Cursor_Value_Input = {
+export type PostsStreamCursorValueInput = {
   /** 内容 */
   content?: InputMaybe<Scalars["String"]["input"]>;
   /** カバー画像 */
@@ -486,16 +486,16 @@ export type Posts_Stream_Cursor_Value_Input = {
   updated_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
 };
 
-export type Query_Root = {
+export type QueryRoot = {
   __typename?: "query_root";
   /** fetch data from the table: "assets" */
   assets: Array<Assets>;
   /** fetch data from the table: "assets" using primary key columns */
   assets_by_pk?: Maybe<Assets>;
   /** An array relationship */
-  post_tags: Array<Post_Tags>;
+  post_tags: Array<PostTags>;
   /** fetch data from the table: "post_tags" using primary key columns */
-  post_tags_by_pk?: Maybe<Post_Tags>;
+  post_tags_by_pk?: Maybe<PostTags>;
   /** An array relationship */
   posts: Array<Posts>;
   /** fetch data from the table: "posts" using primary key columns */
@@ -510,64 +510,64 @@ export type Query_Root = {
   tags_by_pk?: Maybe<Tags>;
 };
 
-export type Query_RootAssetsArgs = {
-  distinct_on?: InputMaybe<Array<Assets_Select_Column>>;
+export type QueryRootAssetsArgs = {
+  distinct_on?: InputMaybe<Array<AssetsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Assets_Order_By>>;
-  where?: InputMaybe<Assets_Bool_Exp>;
+  order_by?: InputMaybe<Array<AssetsOrderBy>>;
+  where?: InputMaybe<AssetsBoolExp>;
 };
 
-export type Query_RootAssets_By_PkArgs = {
+export type QueryRootAssetsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Query_RootPost_TagsArgs = {
-  distinct_on?: InputMaybe<Array<Post_Tags_Select_Column>>;
+export type QueryRootPostTagsArgs = {
+  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Post_Tags_Order_By>>;
-  where?: InputMaybe<Post_Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
 };
 
-export type Query_RootPost_Tags_By_PkArgs = {
+export type QueryRootPostTagsByPkArgs = {
   post_id: Scalars["uuid"]["input"];
   tag_id: Scalars["uuid"]["input"];
 };
 
-export type Query_RootPostsArgs = {
-  distinct_on?: InputMaybe<Array<Posts_Select_Column>>;
+export type QueryRootPostsArgs = {
+  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Posts_Order_By>>;
-  where?: InputMaybe<Posts_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
 };
 
-export type Query_RootPosts_By_PkArgs = {
+export type QueryRootPostsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Query_RootSeosArgs = {
-  distinct_on?: InputMaybe<Array<Seos_Select_Column>>;
+export type QueryRootSeosArgs = {
+  distinct_on?: InputMaybe<Array<SeosSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Seos_Order_By>>;
-  where?: InputMaybe<Seos_Bool_Exp>;
+  order_by?: InputMaybe<Array<SeosOrderBy>>;
+  where?: InputMaybe<SeosBoolExp>;
 };
 
-export type Query_RootSeos_By_PkArgs = {
+export type QueryRootSeosByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Query_RootTagsArgs = {
-  distinct_on?: InputMaybe<Array<Tags_Select_Column>>;
+export type QueryRootTagsArgs = {
+  distinct_on?: InputMaybe<Array<TagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Tags_Order_By>>;
-  where?: InputMaybe<Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<TagsOrderBy>>;
+  where?: InputMaybe<TagsBoolExp>;
 };
 
-export type Query_RootTags_By_PkArgs = {
+export type QueryRootTagsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
@@ -594,68 +594,68 @@ export type Seos = {
 
 /** SEO */
 export type SeosPostsArgs = {
-  distinct_on?: InputMaybe<Array<Posts_Select_Column>>;
+  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Posts_Order_By>>;
-  where?: InputMaybe<Posts_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
 };
 
 /** Boolean expression to filter rows from the table "seos". All fields are combined with a logical 'AND'. */
-export type Seos_Bool_Exp = {
-  _and?: InputMaybe<Array<Seos_Bool_Exp>>;
-  _not?: InputMaybe<Seos_Bool_Exp>;
-  _or?: InputMaybe<Array<Seos_Bool_Exp>>;
-  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  deleted_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  description?: InputMaybe<String_Comparison_Exp>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  og_image_url?: InputMaybe<String_Comparison_Exp>;
-  posts?: InputMaybe<Posts_Bool_Exp>;
-  title?: InputMaybe<String_Comparison_Exp>;
-  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+export type SeosBoolExp = {
+  _and?: InputMaybe<Array<SeosBoolExp>>;
+  _not?: InputMaybe<SeosBoolExp>;
+  _or?: InputMaybe<Array<SeosBoolExp>>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  deleted_at?: InputMaybe<TimestamptzComparisonExp>;
+  description?: InputMaybe<StringComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  og_image_url?: InputMaybe<StringComparisonExp>;
+  posts?: InputMaybe<PostsBoolExp>;
+  title?: InputMaybe<StringComparisonExp>;
+  updated_at?: InputMaybe<TimestamptzComparisonExp>;
 };
 
 /** Ordering options when selecting data from "seos". */
-export type Seos_Order_By = {
-  created_at?: InputMaybe<Order_By>;
-  deleted_at?: InputMaybe<Order_By>;
-  description?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  og_image_url?: InputMaybe<Order_By>;
-  posts_aggregate?: InputMaybe<Posts_Aggregate_Order_By>;
-  title?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
+export type SeosOrderBy = {
+  created_at?: InputMaybe<OrderBy>;
+  deleted_at?: InputMaybe<OrderBy>;
+  description?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  og_image_url?: InputMaybe<OrderBy>;
+  posts_aggregate?: InputMaybe<PostsAggregateOrderBy>;
+  title?: InputMaybe<OrderBy>;
+  updated_at?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "seos" */
-export enum Seos_Select_Column {
+export enum SeosSelectColumn {
   /** column name */
-  CreatedAt = "created_at",
+  CREATED_AT = "created_at",
   /** column name */
-  DeletedAt = "deleted_at",
+  DELETED_AT = "deleted_at",
   /** column name */
-  Description = "description",
+  DESCRIPTION = "description",
   /** column name */
-  Id = "id",
+  ID = "id",
   /** column name */
-  OgImageUrl = "og_image_url",
+  OG_IMAGE_URL = "og_image_url",
   /** column name */
-  Title = "title",
+  TITLE = "title",
   /** column name */
-  UpdatedAt = "updated_at",
+  UPDATED_AT = "updated_at",
 }
 
 /** Streaming cursor of the table "seos" */
-export type Seos_Stream_Cursor_Input = {
+export type SeosStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: Seos_Stream_Cursor_Value_Input;
+  initial_value: SeosStreamCursorValueInput;
   /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
+  ordering?: InputMaybe<CursorOrdering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Seos_Stream_Cursor_Value_Input = {
+export type SeosStreamCursorValueInput = {
   /** 作成日時 */
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** 削除日時 */
@@ -673,7 +673,7 @@ export type Seos_Stream_Cursor_Value_Input = {
 };
 
 /** Boolean expression to compare columns of type "smallint". All fields are combined with logical 'AND'. */
-export type Smallint_Comparison_Exp = {
+export type SmallintComparisonExp = {
   _eq?: InputMaybe<Scalars["smallint"]["input"]>;
   _gt?: InputMaybe<Scalars["smallint"]["input"]>;
   _gte?: InputMaybe<Scalars["smallint"]["input"]>;
@@ -685,7 +685,7 @@ export type Smallint_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars["smallint"]["input"]>>;
 };
 
-export type Subscription_Root = {
+export type SubscriptionRoot = {
   __typename?: "subscription_root";
   /** fetch data from the table: "assets" */
   assets: Array<Assets>;
@@ -694,11 +694,11 @@ export type Subscription_Root = {
   /** fetch data from the table in a streaming manner: "assets" */
   assets_stream: Array<Assets>;
   /** An array relationship */
-  post_tags: Array<Post_Tags>;
+  post_tags: Array<PostTags>;
   /** fetch data from the table: "post_tags" using primary key columns */
-  post_tags_by_pk?: Maybe<Post_Tags>;
+  post_tags_by_pk?: Maybe<PostTags>;
   /** fetch data from the table in a streaming manner: "post_tags" */
-  post_tags_stream: Array<Post_Tags>;
+  post_tags_stream: Array<PostTags>;
   /** An array relationship */
   posts: Array<Posts>;
   /** fetch data from the table: "posts" using primary key columns */
@@ -719,95 +719,95 @@ export type Subscription_Root = {
   tags_stream: Array<Tags>;
 };
 
-export type Subscription_RootAssetsArgs = {
-  distinct_on?: InputMaybe<Array<Assets_Select_Column>>;
+export type SubscriptionRootAssetsArgs = {
+  distinct_on?: InputMaybe<Array<AssetsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Assets_Order_By>>;
-  where?: InputMaybe<Assets_Bool_Exp>;
+  order_by?: InputMaybe<Array<AssetsOrderBy>>;
+  where?: InputMaybe<AssetsBoolExp>;
 };
 
-export type Subscription_RootAssets_By_PkArgs = {
+export type SubscriptionRootAssetsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Subscription_RootAssets_StreamArgs = {
+export type SubscriptionRootAssetsStreamArgs = {
   batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<Assets_Stream_Cursor_Input>>;
-  where?: InputMaybe<Assets_Bool_Exp>;
+  cursor: Array<InputMaybe<AssetsStreamCursorInput>>;
+  where?: InputMaybe<AssetsBoolExp>;
 };
 
-export type Subscription_RootPost_TagsArgs = {
-  distinct_on?: InputMaybe<Array<Post_Tags_Select_Column>>;
+export type SubscriptionRootPostTagsArgs = {
+  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Post_Tags_Order_By>>;
-  where?: InputMaybe<Post_Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
 };
 
-export type Subscription_RootPost_Tags_By_PkArgs = {
+export type SubscriptionRootPostTagsByPkArgs = {
   post_id: Scalars["uuid"]["input"];
   tag_id: Scalars["uuid"]["input"];
 };
 
-export type Subscription_RootPost_Tags_StreamArgs = {
+export type SubscriptionRootPostTagsStreamArgs = {
   batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<Post_Tags_Stream_Cursor_Input>>;
-  where?: InputMaybe<Post_Tags_Bool_Exp>;
+  cursor: Array<InputMaybe<PostTagsStreamCursorInput>>;
+  where?: InputMaybe<PostTagsBoolExp>;
 };
 
-export type Subscription_RootPostsArgs = {
-  distinct_on?: InputMaybe<Array<Posts_Select_Column>>;
+export type SubscriptionRootPostsArgs = {
+  distinct_on?: InputMaybe<Array<PostsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Posts_Order_By>>;
-  where?: InputMaybe<Posts_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostsOrderBy>>;
+  where?: InputMaybe<PostsBoolExp>;
 };
 
-export type Subscription_RootPosts_By_PkArgs = {
+export type SubscriptionRootPostsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Subscription_RootPosts_StreamArgs = {
+export type SubscriptionRootPostsStreamArgs = {
   batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<Posts_Stream_Cursor_Input>>;
-  where?: InputMaybe<Posts_Bool_Exp>;
+  cursor: Array<InputMaybe<PostsStreamCursorInput>>;
+  where?: InputMaybe<PostsBoolExp>;
 };
 
-export type Subscription_RootSeosArgs = {
-  distinct_on?: InputMaybe<Array<Seos_Select_Column>>;
+export type SubscriptionRootSeosArgs = {
+  distinct_on?: InputMaybe<Array<SeosSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Seos_Order_By>>;
-  where?: InputMaybe<Seos_Bool_Exp>;
+  order_by?: InputMaybe<Array<SeosOrderBy>>;
+  where?: InputMaybe<SeosBoolExp>;
 };
 
-export type Subscription_RootSeos_By_PkArgs = {
+export type SubscriptionRootSeosByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Subscription_RootSeos_StreamArgs = {
+export type SubscriptionRootSeosStreamArgs = {
   batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<Seos_Stream_Cursor_Input>>;
-  where?: InputMaybe<Seos_Bool_Exp>;
+  cursor: Array<InputMaybe<SeosStreamCursorInput>>;
+  where?: InputMaybe<SeosBoolExp>;
 };
 
-export type Subscription_RootTagsArgs = {
-  distinct_on?: InputMaybe<Array<Tags_Select_Column>>;
+export type SubscriptionRootTagsArgs = {
+  distinct_on?: InputMaybe<Array<TagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Tags_Order_By>>;
-  where?: InputMaybe<Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<TagsOrderBy>>;
+  where?: InputMaybe<TagsBoolExp>;
 };
 
-export type Subscription_RootTags_By_PkArgs = {
+export type SubscriptionRootTagsByPkArgs = {
   id: Scalars["uuid"]["input"];
 };
 
-export type Subscription_RootTags_StreamArgs = {
+export type SubscriptionRootTagsStreamArgs = {
   batch_size: Scalars["Int"]["input"];
-  cursor: Array<InputMaybe<Tags_Stream_Cursor_Input>>;
-  where?: InputMaybe<Tags_Bool_Exp>;
+  cursor: Array<InputMaybe<TagsStreamCursorInput>>;
+  where?: InputMaybe<TagsBoolExp>;
 };
 
 /** タグ */
@@ -820,7 +820,7 @@ export type Tags = {
   /** タグID */
   id: Scalars["uuid"]["output"];
   /** An array relationship */
-  post_tags: Array<Post_Tags>;
+  post_tags: Array<PostTags>;
   /** タグ */
   tag: Scalars["String"]["output"];
   /** 更新日時 */
@@ -828,61 +828,61 @@ export type Tags = {
 };
 
 /** タグ */
-export type TagsPost_TagsArgs = {
-  distinct_on?: InputMaybe<Array<Post_Tags_Select_Column>>;
+export type TagsPostTagsArgs = {
+  distinct_on?: InputMaybe<Array<PostTagsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
-  order_by?: InputMaybe<Array<Post_Tags_Order_By>>;
-  where?: InputMaybe<Post_Tags_Bool_Exp>;
+  order_by?: InputMaybe<Array<PostTagsOrderBy>>;
+  where?: InputMaybe<PostTagsBoolExp>;
 };
 
 /** Boolean expression to filter rows from the table "tags". All fields are combined with a logical 'AND'. */
-export type Tags_Bool_Exp = {
-  _and?: InputMaybe<Array<Tags_Bool_Exp>>;
-  _not?: InputMaybe<Tags_Bool_Exp>;
-  _or?: InputMaybe<Array<Tags_Bool_Exp>>;
-  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
-  description?: InputMaybe<String_Comparison_Exp>;
-  id?: InputMaybe<Uuid_Comparison_Exp>;
-  post_tags?: InputMaybe<Post_Tags_Bool_Exp>;
-  tag?: InputMaybe<String_Comparison_Exp>;
-  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+export type TagsBoolExp = {
+  _and?: InputMaybe<Array<TagsBoolExp>>;
+  _not?: InputMaybe<TagsBoolExp>;
+  _or?: InputMaybe<Array<TagsBoolExp>>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  description?: InputMaybe<StringComparisonExp>;
+  id?: InputMaybe<UuidComparisonExp>;
+  post_tags?: InputMaybe<PostTagsBoolExp>;
+  tag?: InputMaybe<StringComparisonExp>;
+  updated_at?: InputMaybe<TimestamptzComparisonExp>;
 };
 
 /** Ordering options when selecting data from "tags". */
-export type Tags_Order_By = {
-  created_at?: InputMaybe<Order_By>;
-  description?: InputMaybe<Order_By>;
-  id?: InputMaybe<Order_By>;
-  post_tags_aggregate?: InputMaybe<Post_Tags_Aggregate_Order_By>;
-  tag?: InputMaybe<Order_By>;
-  updated_at?: InputMaybe<Order_By>;
+export type TagsOrderBy = {
+  created_at?: InputMaybe<OrderBy>;
+  description?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  post_tags_aggregate?: InputMaybe<PostTagsAggregateOrderBy>;
+  tag?: InputMaybe<OrderBy>;
+  updated_at?: InputMaybe<OrderBy>;
 };
 
 /** select columns of table "tags" */
-export enum Tags_Select_Column {
+export enum TagsSelectColumn {
   /** column name */
-  CreatedAt = "created_at",
+  CREATED_AT = "created_at",
   /** column name */
-  Description = "description",
+  DESCRIPTION = "description",
   /** column name */
-  Id = "id",
+  ID = "id",
   /** column name */
-  Tag = "tag",
+  TAG = "tag",
   /** column name */
-  UpdatedAt = "updated_at",
+  UPDATED_AT = "updated_at",
 }
 
 /** Streaming cursor of the table "tags" */
-export type Tags_Stream_Cursor_Input = {
+export type TagsStreamCursorInput = {
   /** Stream column input with initial value */
-  initial_value: Tags_Stream_Cursor_Value_Input;
+  initial_value: TagsStreamCursorValueInput;
   /** cursor ordering */
-  ordering?: InputMaybe<Cursor_Ordering>;
+  ordering?: InputMaybe<CursorOrdering>;
 };
 
 /** Initial value of the column from where the streaming should start */
-export type Tags_Stream_Cursor_Value_Input = {
+export type TagsStreamCursorValueInput = {
   /** 作成日時 */
   created_at?: InputMaybe<Scalars["timestamptz"]["input"]>;
   /** 説明文 */
@@ -896,7 +896,7 @@ export type Tags_Stream_Cursor_Value_Input = {
 };
 
 /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
-export type Timestamptz_Comparison_Exp = {
+export type TimestamptzComparisonExp = {
   _eq?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _gt?: InputMaybe<Scalars["timestamptz"]["input"]>;
   _gte?: InputMaybe<Scalars["timestamptz"]["input"]>;
@@ -909,7 +909,7 @@ export type Timestamptz_Comparison_Exp = {
 };
 
 /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
-export type Uuid_Comparison_Exp = {
+export type UuidComparisonExp = {
   _eq?: InputMaybe<Scalars["uuid"]["input"]>;
   _gt?: InputMaybe<Scalars["uuid"]["input"]>;
   _gte?: InputMaybe<Scalars["uuid"]["input"]>;
@@ -929,10 +929,10 @@ export type PostsQuery = {
   __typename?: "query_root";
   posts: Array<{
     __typename?: "posts";
-    id: any;
+    id: string;
     title: string;
     excerpt: string;
-    published_at?: any | null;
+    published_at?: Date | null;
     coverImage?: { __typename?: "assets"; url: string } | null;
   }>;
 };
@@ -941,7 +941,7 @@ export type PostIdsQueryVariables = Exact<{
   now: Scalars["timestamptz"]["input"];
 }>;
 
-export type PostIdsQuery = { __typename?: "query_root"; posts: Array<{ __typename?: "posts"; id: any }> };
+export type PostIdsQuery = { __typename?: "query_root"; posts: Array<{ __typename?: "posts"; id: string }> };
 
 export type PostMetadataQueryVariables = Exact<{
   id: Scalars["uuid"]["input"];
@@ -962,7 +962,7 @@ export type PostQuery = {
     __typename?: "posts";
     title: string;
     excerpt: string;
-    published_at?: any | null;
+    published_at?: Date | null;
     content: string;
     coverImage?: { __typename?: "assets"; url: string } | null;
     post_tags: Array<{ __typename?: "post_tags"; tag: { __typename?: "tags"; tag: string } }>;


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

graphql のスキーマ変更対応を実施します.
併せて uuid, timestamptz が適切な型になるよう対応します.

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://hasura.io/blog/naming-convention-for-graphql-schema-snake-case-vs-camel-case/
- https://the-guild.dev/graphql/codegen/docs/config-reference/naming-convention
- https://pothos-graphql.dev/docs/guide/generating-client-types

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- コード生成プロセスにおいて、命名規則とスカラーに関する設定オプションを追加しました。
- **機能改善**
	- `HeroImage` コンポーネント内で `publishedAt` プロパティの型を `Date | null | undefined` に変更し、表示用に直接フォーマットするようにしました。
	- 投稿カードと投稿内容において、`publishedAt` の存在を確認し、フォーマットして表示するように改善しました。
	- GraphQLのクエリ構造とフィールド名を、一貫性を持たせるために更新しました。
- **バグ修正**
	- 投稿関連のコンポーネントとページで、変数命名規則の一貫性を保つための修正を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->