### PR TITLE
Revert "perf: post-card のヒーロー画像を Next/Image に置き換え"

### DIFF
--- a/apps/frontend/src/app/_features/post/components/post-card.tsx
+++ b/apps/frontend/src/app/_features/post/components/post-card.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { formatDateEn, utcToJstTime } from "@/utils/date";
 import { countText, hasJa } from "@/utils/text";
@@ -20,7 +19,7 @@ export const PostCard: React.FC<Props> = ({ href, title, description, publishedA
       <Link href={href} className="h-full">
         {/* ヒーロー画像 */}
         <div className="relative flex h-40 shrink-0 items-center justify-center overflow-hidden">
-          <Image className="absolute inset-0 m-auto object-cover" src={heroImage} alt={heroText ?? "#"} fill />
+          <img className="absolute inset-0 m-auto object-cover" src={heroImage} alt="#" loading="lazy" />
 
           <span
             className={clsx(


### PR DESCRIPTION
Reverts tatsutakein/tatsutakein.jp#471

502 エラーとなるため
![CleanShot 2024-03-05 at 20 44 45@2x](https://github.com/tatsutakein/tatsutakein.jp/assets/19267812/e81ec2cc-056c-4ce2-93ca-9637f1a7a826)
